### PR TITLE
Add scipy minimum version to install_requires.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ if __name__ == '__main__':
         packages=find_packages(),
         install_requires=[
             'Orange',
+            'scipy>=0.14.0',
         ],
         entry_points=ENTRY_POINTS,
         keywords=KEYWORDS,


### PR DESCRIPTION
v0.14.0 is required for scipy.signal.savgol_filter

Fixes #3 