### PR TITLE
Fix savgol preproc

### DIFF
--- a/orangecontrib/infrared/widgets/owpreproc.py
+++ b/orangecontrib/infrared/widgets/owpreproc.py
@@ -145,7 +145,7 @@ class SavitzkyGolayFilteringEditor(BaseEditor):
 
         self.wspin = QDoubleSpinBox(
             minimum=3, maximum=100, singleStep=2,
-            value=self.polyorder)
+            value=self.window)
         self.wspin.valueChanged[float].connect(self.setW)
         self.wspin.editingFinished.connect(self.edited)
 

--- a/orangecontrib/infrared/widgets/owpreproc.py
+++ b/orangecontrib/infrared/widgets/owpreproc.py
@@ -123,7 +123,7 @@ class SavitzkyGolayFiltering():
         #savgol_filter(x, window_length, polyorder, deriv=0, delta=1.0, axis=-1, mode='interp', cval=0.0)
         newd = savgol_filter(data.X, window_length=self.window, polyorder=self.polyorder, deriv=self.deriv, mode="nearest")
 
-        data = copy.copy(data)
+        data = data.copy()
         data.X = newd
         return data
 


### PR DESCRIPTION
Two small fixes for salgol_filter preproc.

 	[owpreproc] Window spinbox should have value=self.window
	[owpreproc] Change savgol_filter to use data.copy() as well