### PR TITLE
[WIP][owpreproc] Remove markings when preprocessor is not focused.

### DIFF
--- a/orangecontrib/infrared/widgets/owcurves.py
+++ b/orangecontrib/infrared/widgets/owcurves.py
@@ -73,7 +73,7 @@ def searchsorted_cached(cache, arr, v, side="left"):
     if key not in cache:
         cache[key] = np.searchsorted(arr, v, side=side)
     return cache[key]
-        
+
 
 def distancetocurve(array, x, y, xpixel, ypixel, r=5, cache=None):
     if cache is not None and id(x) in cache:
@@ -81,15 +81,15 @@ def distancetocurve(array, x, y, xpixel, ypixel, r=5, cache=None):
     else:
         xmin = closestindex(array[0], x-r*xpixel)
         xmax = closestindex(array[0], x+r*xpixel)
-        if cache is not None: 
+        if cache is not None:
             cache[id(x)] = xmin,xmax
     xp = array[0][xmin:xmax+1]
     yp = array[1][xmin:xmax+1]
-    
+
     #convert to distances in pixels
     xp = ((xp-x)/xpixel)
     yp = ((yp-y)/ypixel)
-    
+
     distancepx = (xp**2+yp**2)**0.5
     mini = np.argmin(distancepx)
     return distancepx[mini], xmin + mini
@@ -377,6 +377,10 @@ class CurvePlot(QWidget):
         self.markings.append(item)
         self.plot.addItem(item, ignoreBounds=True)
 
+    def remove_marking(self, item):
+        self.markings.remove(item)
+        self.plot.removeItem(item)
+
     def add_curves(self, x, data, addc=True):
         """ Add multiple curves with the same x domain. """
         xsind = np.argsort(x)
@@ -641,4 +645,3 @@ def main(argv=None):
 
 if __name__ == "__main__":
     sys.exit(main())
-

--- a/orangecontrib/infrared/widgets/owpreproc.py
+++ b/orangecontrib/infrared/widgets/owpreproc.py
@@ -70,6 +70,12 @@ class FocusFrame(owpreprocess.SequenceFlow.Frame):
         except AttributeError:
             pass
 
+    def focusOutEvent(self, event):
+        super().focusOutEvent(event)
+        try:
+            self.widget().deactivateOptions()
+        except AttributeError:
+            pass
 
 class PreviewFrame(owpreprocess.SequenceFlow.Frame):
 
@@ -438,6 +444,12 @@ class CutEditor(BaseEditor):
             self.parent_widget.curveplot.add_marking(self.line1)
         if self.line2 not in self.parent_widget.curveplot.markings:
             self.parent_widget.curveplot.add_marking(self.line2)
+
+    def deactivateOptions(self):
+        if self.line1 in self.parent_widget.curveplot.markings:
+            self.parent_widget.curveplot.remove_marking(self.line1)
+        if self.line2 in self.parent_widget.curveplot.markings:
+            self.parent_widget.curveplot.remove_marking(self.line2)
 
     def set_lowlim(self, lowlim):
         if self.__lowlim != lowlim:


### PR DESCRIPTION
This adds a few functions to support removing the markings that a preprocessor has added when it looses focus.

Motivation: I love that the markings appear when you click on a preprocessor, but it's going to get very busy as we add more markings for other preprocessors if they all hang around forever. I am planning to use this to make some of my preprocessors more interactive but wanted to make sure we're on the same page first.

PS Sorry about the whitespace noise, I just noticed it now.