### PR TITLE
[owpreproc] Set normalization limits using gui markers

### DIFF
--- a/orangecontrib/infrared/widgets/owpreproc.py
+++ b/orangecontrib/infrared/widgets/owpreproc.py
@@ -745,14 +745,16 @@ class NormalizeEditor(BaseEditor):
         self.limitcb = QComboBox()
         self.limitcb.addItems(["Full Range", "Within Limits"])
 
+        minf,maxf = -sys.float_info.max, sys.float_info.max
+
         self.lspin = QDoubleSpinBox(
-            minimum=0, maximum=16000, singleStep=50,
+            minimum=minf, maximum=maxf, singleStep=0.5,
             value=self.lower, enabled=self.limits)
         self.lspin.valueChanged[float].connect(self.setL)
         self.lspin.editingFinished.connect(self.reorderLimits)
 
         self.uspin = QDoubleSpinBox(
-            minimum=0, maximum=16000, singleStep=50,
+            minimum=minf, maximum=maxf, singleStep=0.5,
             value=self.upper, enabled=self.limits)
         self.uspin.valueChanged[float].connect(self.setU)
         self.uspin.editingFinished.connect(self.reorderLimits)

--- a/orangecontrib/infrared/widgets/owpreproc.py
+++ b/orangecontrib/infrared/widgets/owpreproc.py
@@ -601,28 +601,29 @@ class RubberbandBaseline():
 
     def __call__(self, data):
         x = getx(data)
-        if self.sub == 0:
-            newd = None
-        elif self.sub == 1:
-            newd = data.X
-        for row in data.X:
-            v = ConvexHull(np.column_stack((x, row))).vertices
-            if self.peak_dir == 0:
-                v = np.roll(v, -v.argmax())
-                v = v[:v.argmin()+1]
-            elif self.peak_dir == 1:
-                v = np.roll(v, -v.argmin())
-                v = v[:v.argmax()+1]
-            baseline = interp1d(x[v], row[v])(x)
-            if newd is not None and self.sub == 0:
-                newd = np.vstack((newd, (row - baseline)))
-            elif newd is not None and self.sub == 1:
-                newd = np.vstack((newd, baseline))
-            else:
-                newd = row - baseline
-                newd = newd[None,:]
-        data = data.copy()
-        data.X = newd
+        if len(x) > 0 and data.X.size > 0:
+            if self.sub == 0:
+                newd = None
+            elif self.sub == 1:
+                newd = data.X
+            for row in data.X:
+                v = ConvexHull(np.column_stack((x, row))).vertices
+                if self.peak_dir == 0:
+                    v = np.roll(v, -v.argmax())
+                    v = v[:v.argmin()+1]
+                elif self.peak_dir == 1:
+                    v = np.roll(v, -v.argmin())
+                    v = v[:v.argmax()+1]
+                baseline = interp1d(x[v], row[v])(x)
+                if newd is not None and self.sub == 0:
+                    newd = np.vstack((newd, (row - baseline)))
+                elif newd is not None and self.sub == 1:
+                    newd = np.vstack((newd, baseline))
+                else:
+                    newd = row - baseline
+                    newd = newd[None,:]
+            data = data.copy()
+            data.X = newd
         return data
 
 
@@ -679,9 +680,9 @@ class Normalize():
         self.limits = limits
 
     def __call__(self, data):
-        if len(data.domain.attributes) > 0:
-            x = getx(data)
+        x = getx(data)
 
+        if len(x) > 0 and data.X.size > 0:
             data = data.copy()
 
             if self.limits == 1:

--- a/orangecontrib/infrared/widgets/owpreproc.py
+++ b/orangecontrib/infrared/widgets/owpreproc.py
@@ -750,19 +750,19 @@ class NormalizeEditor(BaseEditor):
         self.lspin = QDoubleSpinBox(
             minimum=minf, maximum=maxf, singleStep=0.5,
             value=self.lower, enabled=self.limits)
-        self.lspin.valueChanged[float].connect(self.setL)
-        self.lspin.editingFinished.connect(self.reorderLimits)
-
         self.uspin = QDoubleSpinBox(
             minimum=minf, maximum=maxf, singleStep=0.5,
             value=self.upper, enabled=self.limits)
-        self.uspin.valueChanged[float].connect(self.setU)
-        self.uspin.editingFinished.connect(self.reorderLimits)
 
         form.addRow("Normalize region", self.limitcb)
         form.addRow("Lower limit", self.lspin)
         form.addRow("Upper limit", self.uspin)
         self.layout().addLayout(form)
+
+        self.lspin.valueChanged[float].connect(self.setL)
+        self.lspin.editingFinished.connect(self.reorderLimits)
+        self.uspin.valueChanged[float].connect(self.setU)
+        self.uspin.editingFinished.connect(self.reorderLimits)
         self.limitcb.currentIndexChanged.connect(self.setlimittype)
         self.limitcb.activated.connect(self.edited)
 

--- a/orangecontrib/infrared/widgets/owpreproc.py
+++ b/orangecontrib/infrared/widgets/owpreproc.py
@@ -766,15 +766,19 @@ class NormalizeEditor(BaseEditor):
         self.limitcb.currentIndexChanged.connect(self.setlimittype)
         self.limitcb.activated.connect(self.edited)
 
+        self.user_changed = False
+
     def setParameters(self, params):
+        if params: #parameters were manually set somewhere else
+            self.user_changed = True
         method = params.get("method", Normalize.MinMax)
         lower = params.get("lower", 0)
         upper = params.get("upper", 4000)
         limits = params.get("limits", 0)
         self.setMethod(method)
         self.limitcb.setCurrentIndex(limits)
-        self.setL(lower)
-        self.setU(upper)
+        self.setL(lower, user=False)
+        self.setU(upper, user=False)
 
     def parameters(self):
         return {"method": self.__method, "lower": self.lower,
@@ -787,13 +791,17 @@ class NormalizeEditor(BaseEditor):
             b.setChecked(True)
             self.changed.emit()
 
-    def setL(self, lower):
+    def setL(self, lower, user=True):
+        if user:
+            self.user_changed = True
         if self.lower != lower:
             self.lower = lower
             self.lspin.setValue(lower)
             self.changed.emit()
 
-    def setU(self, upper):
+    def setU(self, upper, user=True):
+        if user:
+            self.user_changed = True
         if self.upper != upper:
             self.upper = upper
             self.uspin.setValue(upper)
@@ -826,6 +834,13 @@ class NormalizeEditor(BaseEditor):
         upper = params.get("upper", 4000)
         limits = params.get("limits", 0)
         return Normalize(method=method,lower=lower,upper=upper,limits=limits)
+
+    def set_preview_data(self, data):
+        if not self.user_changed:
+            x = getx(data)
+            if len(x):
+                self.setL(min(x))
+                self.setU(max(x))
 
 
 PREPROCESSORS = [

--- a/orangecontrib/infrared/widgets/owpreproc.py
+++ b/orangecontrib/infrared/widgets/owpreproc.py
@@ -676,31 +676,32 @@ class Normalize():
         self.limits = limits
 
     def __call__(self, data):
-        x = getx(data)
+        if len(data.domain.attributes) > 0:
+            x = getx(data)
 
-        data = data.copy()
+            data = data.copy()
 
-        if self.limits == 1:
-            x_sorter = np.argsort(x)
-            limits = np.searchsorted(x, [self.lower, self.upper], sorter=x_sorter)
-            y_s = data.X[:,x_sorter][:,limits[0]:limits[1]]
-        else:
-            y_s = data.X
+            if self.limits == 1:
+                x_sorter = np.argsort(x)
+                limits = np.searchsorted(x, [self.lower, self.upper], sorter=x_sorter)
+                y_s = data.X[:,x_sorter][:,limits[0]:limits[1]]
+            else:
+                y_s = data.X
 
-        if self.method == self.MinMax:
-            data.X /= np.max(np.abs(y_s), axis=1, keepdims=True)
-        elif self.method == self.Vector:
-            # zero offset correction applies to entire spectrum, regardless of limits
-            y_offsets = np.mean(data.X, axis=1, keepdims=True)
-            data.X -= y_offsets
-            y_s -= y_offsets
-            rssq = np.sqrt(np.sum(y_s**2, axis=1, keepdims=True))
-            data.X /= rssq
-        elif self.method == self.Offset:
-            data.X -= np.min(y_s, axis=1, keepdims=True)
-        elif self.method == self.Attribute:
-            # Not implemented
-            pass
+            if self.method == self.MinMax:
+                data.X /= np.max(np.abs(y_s), axis=1, keepdims=True)
+            elif self.method == self.Vector:
+                # zero offset correction applies to entire spectrum, regardless of limits
+                y_offsets = np.mean(data.X, axis=1, keepdims=True)
+                data.X -= y_offsets
+                y_s -= y_offsets
+                rssq = np.sqrt(np.sum(y_s**2, axis=1, keepdims=True))
+                data.X /= rssq
+            elif self.method == self.Offset:
+                data.X -= np.min(y_s, axis=1, keepdims=True)
+            elif self.method == self.Attribute:
+                # Not implemented
+                pass
 
         return data
 

--- a/orangecontrib/infrared/widgets/owpreproc.py
+++ b/orangecontrib/infrared/widgets/owpreproc.py
@@ -390,7 +390,10 @@ class MovableVlineWD(pg.UIGraphicsItem):
         if self.setvalfn:
             self.setvalfn(self.value())
         if self.confirmfn:
-            self.confirmfn.emit()
+            if hasattr(self.confirmfn, "emit"):
+                self.confirmfn.emit()
+            else:
+                self.confirmfn()
 
     def paint(self, p, *args):
         tr = p.transform()


### PR DESCRIPTION
This PR uses the new gui markers to set the normalization limits (when desired).

Also includes some work to bring NormalizeEditor up to the level of CutEditor and some dataset sets to avoid crashing when passed an empty dataset (for example, from Cut set to 0.0-1.0)