### PR TITLE
Fix preproc rubberband

### DIFF
--- a/orangecontrib/infrared/widgets/owpreproc.py
+++ b/orangecontrib/infrared/widgets/owpreproc.py
@@ -14,7 +14,7 @@ from PyQt4.QtGui import (
     QVBoxLayout, QHBoxLayout, QFormLayout, QSpacerItem, QSizePolicy,
     QCursor, QIcon,  QStandardItemModel, QStandardItem, QStyle,
     QStylePainter, QStyleOptionFrame, QPixmap,
-    QApplication, QDrag
+    QApplication, QDrag, QPushButton, QLabel
 )
 from PyQt4 import QtGui
 from PyQt4.QtCore import (
@@ -897,28 +897,38 @@ class Integrate():
     Simple, Baseline = 0, 1
 
 
-    def __init__(self, method=Baseline, lowlim=None, highlim=None):
+    def __init__(self, method=Baseline, limits=[]):
         self.method = method
-        self.lowlim = lowlim
-        self.highlim = highlim
+        self.limits = limits
 
     def __call__(self, data):
         x = getx(data)
-        if len(x) > 0 and data.X.size > 0 and self.lowlim != None and self.highlim != None:
+        if len(x) > 0 and data.X.size > 0 and self.limits:
             x_sorter = np.argsort(x)
-            limits = np.searchsorted(x, [self.lowlim, self.highlim], sorter=x_sorter)
-            x_s = x[x_sorter][limits[0]:limits[1]]
-            y_s = data.X[:,x_sorter][:,limits[0]:limits[1]]
-            newd = self.IntMethods[self.method](y_s, x_s)
-            range_str = "%s - %s" % (x_s[0], x_s[-1])
-            range_attr = [Orange.data.ContinuousVariable(name=range_str)]
-            domain = Orange.data.Domain(range_attr, data.domain.class_vars,
-                                        metas=data.domain.metas)
-            table = Orange.data.Table.from_numpy(domain, newd[:,None],
-                                                 Y=data.Y, metas=data.metas)
-        else:
-            table = data
-        return table
+            all_limits = np.searchsorted(x, self.limits, sorter=x_sorter)
+            range_attrs = []
+            newd = None
+            for limits in all_limits:
+                try:
+                    x_s = x[x_sorter][limits[0]:limits[1]]
+                except IndexError:
+                    continue
+                y_s = data.X[:,x_sorter][:,limits[0]:limits[1]]
+                try:
+                    newd = np.column_stack((newd, self.IntMethods[self.method](y_s, x_s)))
+                except ValueError:
+                    newd = self.IntMethods[self.method](y_s, x_s)[:,None]
+                except IndexError:
+                    continue
+                range_str = "%s - %s" % (x_s[0], x_s[-1])
+                range_attrs.append(Orange.data.ContinuousVariable(name=range_str))
+            if newd is not None:
+                domain = Orange.data.Domain(range_attrs, data.domain.class_vars,
+                                            metas=data.domain.metas)
+                data = Orange.data.Table.from_numpy(domain, newd,
+                                                     Y=data.Y, metas=data.metas)
+
+        return data
 
     def simpleInt(y, x):
         """
@@ -938,6 +948,70 @@ class Integrate():
 
     IntMethods = [simpleInt, baselineInt]
 
+class LimitsBox(QHBoxLayout):
+    """
+    Box with two limits
+
+    Args:
+        limits (list): List containing low and high limit set
+        label  (str) : Label widget
+        delete (bool): Include self-deletion button
+    """
+
+    valueChanged = Signal(list, QObject)
+    deleted = Signal(QObject)
+
+    def __init__(self, parent=None, **kwargs):
+        limits = kwargs.pop('limits', None)
+        label = kwargs.pop('label', None)
+        delete = kwargs.pop('delete', True)
+        super().__init__(parent, **kwargs)
+
+        minf,maxf = -sys.float_info.max, sys.float_info.max
+
+        if label:
+            self.addWidget(QLabel(label))
+
+        self.lowlime = SetXDoubleSpinBox(decimals=4,
+            minimum=minf, maximum=maxf, singleStep=0.5,
+            value=limits[0], maximumWidth=75)
+        self.highlime = SetXDoubleSpinBox(decimals=4,
+            minimum=minf, maximum=maxf, singleStep=0.5,
+            value=limits[1], maximumWidth=75)
+        self.addWidget(self.lowlime)
+        self.addWidget(self.highlime)
+
+        if delete:
+            self.button = QPushButton(QApplication.style().standardIcon(QStyle.SP_DockWidgetCloseButton), "")
+            self.addWidget(self.button)
+            self.button.clicked.connect(self.selfDelete)
+
+        self.lowlime.valueChanged[float].connect(self.limitChanged)
+        self.highlime.valueChanged[float].connect(self.limitChanged)
+
+        self.lowlime.focusIn = self.focusInChild
+        self.highlime.focusIn = self.focusInChild
+
+    def focusInEvent(self, *e):
+        self.focusIn()
+        return super().focusInEvent(*e)
+
+    def focusInChild(self):
+        self.focusIn()
+
+    def limitChanged(self):
+        newlimits = [self.lowlime.value(), self.highlime.value()]
+        self.valueChanged.emit(newlimits, self)
+
+    def selfDelete(self):
+        self.deleted.emit(self)
+        self.removeLayout()
+
+    def removeLayout(self):
+        while self.count():
+            self.takeAt(0).widget().setParent(None)
+        self.setParent(None)
+
 class IntegrateEditor(BaseEditor):
     """
     Editor to integrate defined regions.
@@ -949,44 +1023,35 @@ class IntegrateEditor(BaseEditor):
     def __init__(self, parent=None, **kwargs):
         super().__init__(parent, **kwargs)
 
-        self.__lowlim = 0.
-        self.__highlim = 1.
+        self._limits = []
 
-        layout = QFormLayout()
-
-        self.setLayout(layout)
-
-        minf,maxf = -sys.float_info.max, sys.float_info.max
-
-        self.__lowlime = SetXDoubleSpinBox(decimals=4,
-            minimum=minf, maximum=maxf, singleStep=0.5, value=self.__lowlim)
-        self.__highlime = SetXDoubleSpinBox(decimals=4,
-            minimum=minf, maximum=maxf, singleStep=0.5, value=self.__highlim)
-
-        layout.addRow("Low limit", self.__lowlime)
-        layout.addRow("High limit", self.__highlime)
-
-        self.__lowlime.focusIn = self.activateOptions
-        self.__highlime.focusIn = self.activateOptions
-        self.focusIn = self.activateOptions
-
-        self.__lowlime.valueChanged[float].connect(self.set_lowlim)
-        self.__highlime.valueChanged[float].connect(self.set_highlim)
-        self.__lowlime.editingFinished.connect(self.edited)
-        self.__highlime.editingFinished.connect(self.edited)
-        self.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Preferred)
-
-        self.line1 = MovableVlineWD(position=self.__lowlim, label="Low limit", setvalfn=self.set_lowlim, confirmfn=self.edited)
-        self.line2 = MovableVlineWD(position=self.__highlim, label="High limit", setvalfn=self.set_highlim, confirmfn=self.edited)
-
-        self.user_changed = False
+        self.setLayout(QVBoxLayout())
+        self.form_set = QFormLayout()
+        self.form_lim = QFormLayout()
+        self.layout().addLayout(self.form_set)
+        self.layout().addLayout(self.form_lim)
 
         self.methodcb = QComboBox()
         self.methodcb.addItems(self.Integrators)
 
-        self.layout().insertRow(0, "Integration method", self.methodcb)
+        self.form_set.addRow("Integration method:", self.methodcb)
         self.methodcb.currentIndexChanged.connect(self.changed)
         self.methodcb.activated.connect(self.edited)
+
+        self.focusIn = self.activateOptions
+
+        self.add_limit()
+
+        button = QPushButton("Add Region")
+        self.layout().addWidget(button)
+        button.clicked.connect(self.add_limit)
+
+        self.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Preferred)
+
+        self.line1 = MovableVlineWD(position=self._limits[0][0], label="Low limit", setvalfn=self.set_limits, confirmfn=self.edited)
+        self.line2 = MovableVlineWD(position=self._limits[0][1], label="High limit", setvalfn=self.set_limits, confirmfn=self.edited)
+
+        self.user_changed = False
 
     def activateOptions(self):
         self.parent_widget.curveplot.clear_markings()
@@ -995,50 +1060,81 @@ class IntegrateEditor(BaseEditor):
         if self.line2 not in self.parent_widget.curveplot.markings:
             self.parent_widget.curveplot.add_marking(self.line2)
 
-    def set_lowlim(self, lowlim, user=True):
+    def add_limit(self, *args, row=None):
+        if row is None:
+            row = len(self._limits)
+            try:
+                self._limits.append(self._limits[-1])
+            except IndexError:
+                self._limits.append([0.,1.])
+        label = "Region {0}".format(row+1)
+        limitbox = LimitsBox(limits=self._limits[row], label=label)
+        if self.form_lim.rowCount() < row+1:
+            # new row
+            self.form_lim.addRow(limitbox)
+        else:
+            # row already exists
+            self.form_lim.setLayout(row, 2, limitbox)
+        limitbox.focusIn = self.activateOptions
+        limitbox.valueChanged.connect(self.set_limits)
+        limitbox.deleted.connect(self.remove_limit)
+        limitbox.lowlime.editingFinished.connect(self.edited)
+        limitbox.highlime.editingFinished.connect(self.edited)
+        return limitbox
+
+    def remove_limit(self, limitbox):
+        row, role = self.form_lim.getLayoutPosition(limitbox)
+        for r in range(row, len(self._limits)):
+            limitbox = self.form_lim.itemAt(r, 1)
+            limitbox.removeLayout()
+        self._limits.pop(row)
+        self.set_all_limits(self._limits)
+
+    def set_limits(self, limits, limitbox, user=True):
         if user:
             self.user_changed = True
-        if self.__lowlim != lowlim:
-            self.__lowlim = lowlim
-            with blocked(self.__lowlime):
-                self.__lowlime.setValue(lowlim)
-                self.line1.setValue(lowlim)
+        row, role = self.form_lim.getLayoutPosition(limitbox)
+        if self._limits[row] != limits:
+            self._limits[row] = limits
+            with blocked(self.form_lim):
+                limitbox.lowlime.setValue(limits[0])
+                limitbox.highlime.setValue(limits[1])
             self.changed.emit()
 
-    def set_highlim(self, highlim, user=True):
+    def set_all_limits(self, limits, user=True):
         if user:
             self.user_changed = True
-        if self.__highlim != highlim:
-            self.__highlim = highlim
-            with blocked(self.__highlime):
-                self.__highlime.setValue(highlim)
-                self.line2.setValue(highlim)
-            self.changed.emit()
+        self._limits = limits
+        for row in range(len(limits)):
+            limitbox = self.form_lim.itemAt(row, 1)
+            if limitbox is None:
+                limitbox = self.add_limit(row=row)
+            with blocked(limitbox):
+                limitbox.lowlime.setValue(limits[row][0])
+                limitbox.highlime.setValue(limits[row][1])
+        self.changed.emit()
 
     def setParameters(self, params):
         if params: #parameters were manually set somewhere else
             self.user_changed = True
         self.methodcb.setCurrentIndex(params.get("method", Integrate.Baseline))
-        self.set_lowlim(params.get("lowlim", 0.), user=False)
-        self.set_highlim(params.get("highlim", 1.), user=False)
+        self.set_all_limits(params.get("limits", [[0.,1.]]), user=False)
 
     def parameters(self):
         return {"method": self.methodcb.currentIndex(),
-                "lowlim": self.__lowlim, "highlim": self.__highlim}
+                "limits": self._limits}
 
     @staticmethod
     def createinstance(params):
         method = params.get("method", Integrate.Baseline)
-        lowlim = params.get("lowlim", None)
-        highlim = params.get("highlim", None)
-        return Integrate(method=method, lowlim=lowlim, highlim=highlim)
+        limits = params.get("limits", [[]])
+        return Integrate(method=method, limits=limits)
 
     def set_preview_data(self, data):
         if not self.user_changed:
             x = getx(data)
             if len(x):
-                self.set_lowlim(min(x))
-                self.set_highlim(max(x))
+                self.set_all_limits([[min(x),max(x)]])
 
 PREPROCESSORS = [
     PreprocessAction(


### PR DESCRIPTION
It is possible that the dataset may contain rows with NaNs in the attributes, which causes Qhull to error out. This adds a try-except block to handle that error. 
Can be easily triggered by normalizing by an attribute that is NaN