### PR TITLE
[owpreproc] Normalize: Ensure factors array is floats for type safe true_divide 

### DIFF
--- a/orangecontrib/infrared/widgets/owpreproc.py
+++ b/orangecontrib/infrared/widgets/owpreproc.py
@@ -716,7 +716,7 @@ class Normalize():
                 # meta indices are -ve and start at -1
                 if self.attr not in (None, "None", ""):
                     attr_index = -1-data.domain.index(self.attr)
-                    factors = data.metas[:, attr_index]
+                    factors = data.metas[:, attr_index].astype(float)
                     data.X /= factors[:, None]
 
         return data


### PR DESCRIPTION
Test dataset on fresh Windows install triggered this error:

```
TypeError: ufunc 'true_divide' output (typecode 'O') could not be coerced to provided
output parameter (typecode 'd') according to the casting rule ''same_kind''
```