### PR TITLE
Use ContinuousVariable.make() constructor consistently

### DIFF
--- a/orangecontrib/infrared/data.py
+++ b/orangecontrib/infrared/data.py
@@ -11,7 +11,7 @@ class DptReader(FileFormat):
     def read(self):
         tbl = np.loadtxt(self.filename)
         domvals = tbl.T[0]  # first column is attribute name
-        domain = Orange.data.Domain([Orange.data.ContinuousVariable("%f" % f) for f in domvals], None)
+        domain = Orange.data.Domain([Orange.data.ContinuousVariable.make("%f" % f) for f in domvals], None)
         datavals = tbl.T[1:]
         return Orange.data.Table(domain, datavals)
 

--- a/orangecontrib/infrared/widgets/owpreproc.py
+++ b/orangecontrib/infrared/widgets/owpreproc.py
@@ -927,7 +927,7 @@ class Integrate():
                 except IndexError:
                     continue
                 range_str = "%s - %s" % (x_s[0], x_s[-1])
-                range_attrs.append(Orange.data.ContinuousVariable(name=range_str))
+                range_attrs.append(Orange.data.ContinuousVariable.make(range_str))
             if newd is not None:
                 domain = Orange.data.Domain(range_attrs, data.domain.class_vars,
                                             metas=data.domain.metas)


### PR DESCRIPTION
Identically named variables won't test as equal unless .make() is used[1]

[1] http://docs.orange.biolab.si/3/data-mining-library/reference/data.variable.html#constructors