### PR TITLE
Opus reader

### DIFF
--- a/orangecontrib/infrared/data.py
+++ b/orangecontrib/infrared/data.py
@@ -123,10 +123,10 @@ class OmnicMapReader(FileFormat):
         pass #not implemented
 
 
-class OPUS2DReader(FileFormat):
-    """Reader for 2D OPUS files"""
-    EXTENSIONS = ('.0', '.1')
-    DESCRIPTION = 'OPUS 3D Spectra'
+class OPUSReader(FileFormat):
+    """Reader for OPUS files"""
+    EXTENSIONS = ('.0', '.1', '.2', '.3', '.4')
+    DESCRIPTION = 'OPUS Spectrum'
 
     @property
     def sheets(self):
@@ -156,21 +156,24 @@ class OPUS2DReader(FileFormat):
         attrs = [Orange.data.ContinuousVariable.make(repr(data.x[i]))
                     for i in range(data.x.shape[0])]
 
-        metas = [Orange.data.ContinuousVariable.make('map_x'),
-                 Orange.data.ContinuousVariable.make('map_y')]
-
         y_data = None
         meta_data = None
 
-        for i in np.ndindex(data.spectra.shape[:1]):
-            map_y = np.full_like(data.mapX, data.mapY[i])
-            coord = np.column_stack((data.mapX, map_y))
-            if y_data is None:
-                y_data = data.spectra[i]
-                meta_data = coord
-            else:
-                y_data = np.vstack((y_data, data.spectra[i]))
-                meta_data = np.vstack((meta_data, coord))
+        if dim == '3D':
+            metas = [Orange.data.ContinuousVariable.make('map_x'),
+                     Orange.data.ContinuousVariable.make('map_y')]
+
+            for i in np.ndindex(data.spectra.shape[:1]):
+                map_y = np.full_like(data.mapX, data.mapY[i])
+                coord = np.column_stack((data.mapX, map_y))
+                if y_data is None:
+                    y_data = data.spectra[i]
+                    meta_data = coord
+                else:
+                    y_data = np.vstack((y_data, data.spectra[i]))
+                    meta_data = np.vstack((meta_data, coord))
+        elif dim == '2D':
+            y_data = data.y[None,:]
 
         domain = Orange.data.Domain(attrs, clses, metas)
 

--- a/orangecontrib/infrared/data.py
+++ b/orangecontrib/infrared/data.py
@@ -146,10 +146,11 @@ class OPUSReader(FileFormat):
         else:
             db = self.sheets[0]
 
-        db, dim, deriv = db.split(" ")
+        db = tuple(db.split(" "))
+        dim = db[1]
 
         try:
-            data = opusFC.getOpusData(self.filename, db, dim, deriv)
+            data = opusFC.getOpusData(self.filename, db)
         except Exception:
             raise IOError("Couldn't load spectrum from " + self.filename)
 

--- a/orangecontrib/infrared/data.py
+++ b/orangecontrib/infrared/data.py
@@ -183,7 +183,7 @@ class OPUSReader(FileFormat):
             pass # TODO notify user?
         else:
             metas.extend([TimeVariable.make('Start time')])
-            if meta_data:
+            if meta_data is not None:
                 dates = np.full(meta_data[:,0].shape, stime, np.array(stime).dtype)
                 meta_data = np.column_stack((meta_data, dates.astype(object)))
             else:
@@ -204,7 +204,7 @@ class OPUSReader(FileFormat):
                 else:
                     raise ValueError #Found a type to handle
                 metas.extend([var])
-                if meta_data:
+                if meta_data is not None:
                     # NB dtype default will be np.array(fill_value).dtype in future
                     params = np.full(meta_data[:,0].shape, param, np.array(param).dtype)
                     meta_data = np.column_stack((meta_data, params.astype(object)))

--- a/orangecontrib/infrared/data.py
+++ b/orangecontrib/infrared/data.py
@@ -161,8 +161,10 @@ class OPUS2DReader(FileFormat):
 
         y_data = None
         meta_data = None
-        for i in np.ndindex(data.spectra.shape[:2]):
-            coord = np.array((data.mapX[i[0]], data.mapY[i[1]]))
+
+        for i in np.ndindex(data.spectra.shape[:1]):
+            map_y = np.full_like(data.mapX, data.mapY[i])
+            coord = np.column_stack((data.mapX, map_y))
             if y_data is None:
                 y_data = data.spectra[i]
                 meta_data = coord

--- a/orangecontrib/infrared/data.py
+++ b/orangecontrib/infrared/data.py
@@ -125,7 +125,7 @@ class OmnicMapReader(FileFormat):
 
 class OPUSReader(FileFormat):
     """Reader for OPUS files"""
-    EXTENSIONS = ('.0', '.1', '.2', '.3', '.4')
+    EXTENSIONS = tuple('.{0}'.format(i) for i in range(100))
     DESCRIPTION = 'OPUS Spectrum'
 
     @property

--- a/orangecontrib/infrared/data.py
+++ b/orangecontrib/infrared/data.py
@@ -166,14 +166,21 @@ class OPUSReader(FileFormat):
             metas.extend([ContinuousVariable.make('map_x'),
                           ContinuousVariable.make('map_y')])
 
-            for i in np.ndindex(data.spectra.shape[:1]):
+            if db[0] == 'TRC':
+                attrs = [ContinuousVariable.make(repr(data.labels[i]))
+                            for i in range(len(data.labels))]
+                data_3D = data.traces
+            else:
+                data_3D = data.spectra
+
+            for i in np.ndindex(data_3D.shape[:1]):
                 map_y = np.full_like(data.mapX, data.mapY[i])
                 coord = np.column_stack((data.mapX, map_y))
                 if y_data is None:
-                    y_data = data.spectra[i]
+                    y_data = data_3D[i]
                     meta_data = coord.astype(object)
                 else:
-                    y_data = np.vstack((y_data, data.spectra[i]))
+                    y_data = np.vstack((y_data, data_3D[i]))
                     meta_data = np.vstack((meta_data, coord))
         elif dim == '2D':
             y_data = data.y[None,:]

--- a/orangecontrib/infrared/data.py
+++ b/orangecontrib/infrared/data.py
@@ -160,8 +160,8 @@ class OPUSReader(FileFormat):
         meta_data = None
 
         if dim == '3D':
-            metas = [Orange.data.ContinuousVariable.make('map_x'),
-                     Orange.data.ContinuousVariable.make('map_y')]
+            metas.extend([Orange.data.ContinuousVariable.make('map_x'),
+                     Orange.data.ContinuousVariable.make('map_y')])
 
             for i in np.ndindex(data.spectra.shape[:1]):
                 map_y = np.full_like(data.mapX, data.mapY[i])
@@ -174,6 +174,19 @@ class OPUSReader(FileFormat):
                     meta_data = np.vstack((meta_data, coord))
         elif dim == '2D':
             y_data = data.y[None,:]
+
+        try:
+            stime = data.parameters['SRT']
+        except Exception:
+            raise
+        else:
+            metas.extend([Orange.data.TimeVariable.make('Start time')])
+            if meta_data:
+                dates = np.empty_like(meta_data[:,1])
+                dates[:] = stime
+                meta_data = np.column_stack((meta_data, dates))
+            else:
+                meta_data = np.array([stime])[None,:]
 
         domain = Orange.data.Domain(attrs, clses, metas)
 

--- a/orangecontrib/infrared/data.py
+++ b/orangecontrib/infrared/data.py
@@ -190,7 +190,7 @@ class OPUSReader(FileFormat):
         except KeyError:
             pass # TODO notify user?
         else:
-            metas.extend([TimeVariable.make('Start time')])
+            metas.extend([TimeVariable.make(opusFC.paramDict['SRT'])])
             if meta_data is not None:
                 dates = np.full(meta_data[:,0].shape, stime, np.array(stime).dtype)
                 meta_data = np.column_stack((meta_data, dates.astype(object)))
@@ -199,12 +199,16 @@ class OPUSReader(FileFormat):
 
         import_params = ['SNM']
 
-        for param_name in import_params:
+        for param_key in import_params:
             try:
-                param = data.parameters[param_name]
+                param = data.parameters[param_key]
             except Exception:
                 pass # TODO should notify user?
             else:
+                try:
+                    param_name = opusFC.paramDict[param_key]
+                except KeyError:
+                    param_name = param_key
                 if type(param) is float:
                     var = ContinuousVariable.make(param_name)
                 elif type(param) is str:

--- a/orangecontrib/infrared/data.py
+++ b/orangecontrib/infrared/data.py
@@ -179,8 +179,8 @@ class OPUSReader(FileFormat):
 
         try:
             stime = data.parameters['SRT']
-        except Exception:
-            raise
+        except KeyError:
+            pass # TODO notify user?
         else:
             metas.extend([TimeVariable.make('Start time')])
             if meta_data:
@@ -209,7 +209,7 @@ class OPUSReader(FileFormat):
                     params = np.full(meta_data[:,0].shape, param, np.array(param).dtype)
                     meta_data = np.column_stack((meta_data, params.astype(object)))
                 else:
-                    meta_data = np.array([stime])[None,:]
+                    meta_data = np.array([param])[None,:]
 
         domain = Orange.data.Domain(attrs, clses, metas)
 

--- a/orangecontrib/infrared/data.py
+++ b/orangecontrib/infrared/data.py
@@ -1,10 +1,12 @@
-from Orange.data.io import FileFormat
 import numpy as np
 import Orange
-from .pymca5 import OmnicMap
+from Orange.data.io import FileFormat
+from Orange.data import \
+    ContinuousVariable, StringVariable, TimeVariable, DiscreteVariable
 import spectral.io.envi
 import itertools
 
+from .pymca5 import OmnicMap
 
 class DptReader(FileFormat):
     """ Reader for files with two columns of numbers (X and Y)"""
@@ -153,15 +155,15 @@ class OPUSReader(FileFormat):
 
         attrs, clses, metas = [], [], []
 
-        attrs = [Orange.data.ContinuousVariable.make(repr(data.x[i]))
+        attrs = [ContinuousVariable.make(repr(data.x[i]))
                     for i in range(data.x.shape[0])]
 
         y_data = None
         meta_data = None
 
         if dim == '3D':
-            metas.extend([Orange.data.ContinuousVariable.make('map_x'),
-                     Orange.data.ContinuousVariable.make('map_y')])
+            metas.extend([ContinuousVariable.make('map_x'),
+                          ContinuousVariable.make('map_y')])
 
             for i in np.ndindex(data.spectra.shape[:1]):
                 map_y = np.full_like(data.mapX, data.mapY[i])
@@ -180,7 +182,7 @@ class OPUSReader(FileFormat):
         except Exception:
             raise
         else:
-            metas.extend([Orange.data.TimeVariable.make('Start time')])
+            metas.extend([TimeVariable.make('Start time')])
             if meta_data:
                 dates = np.empty_like(meta_data[:,1])
                 dates[:] = stime

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ if __name__ == '__main__':
             'Orange3',
             'scipy>=0.14.0',
             'spectral>=0.18',
+            'opusFC>=1.0.0b1',
         ],
         entry_points=ENTRY_POINTS,
         keywords=KEYWORDS,


### PR DESCRIPTION
This PR will add the ability to load OPUS binary files. It depends on the opusFC module:

Issues to discuss before merging:
  1. I didn't rebase on the latest master as I noticed that #33 requires a version of Orange later than what our users can install (only 3.3.7 is available so far)
  2. I added opusFC to `install_requires` but I'm not sure about this: on the one hand, it means users installing orange-infrared automatically get OPUS support. But the downside is that users with problems with installing opusFC will be unable to install orange-infrared at all. I'm not sure there is a great solution to this.
  3. I haven't quite got MacOS .whls of opusFC up yet, so sorry Feri :)

I look forward to your comments and suggestions.