### PR TITLE
OPUSReader: OpusFC 1.1.0 support (multiregion and time-resolved 3D files)

### DIFF
--- a/orangecontrib/infrared/data.py
+++ b/orangecontrib/infrared/data.py
@@ -186,6 +186,24 @@ class OPUSReader(FileFormat):
             y_data = np.vstack(y_data)
             meta_data = np.vstack(meta_data)
 
+        elif type(data) == opusFC.MultiRegionTRCDataReturn:
+            y_data = []
+            meta_data = []
+            metas.extend([ContinuousVariable.make('map_x'),
+                          ContinuousVariable.make('map_y'),
+                          StringVariable.make('map_region')])
+            attrs = [ContinuousVariable.make(repr(data.labels[i]))
+                        for i in range(len(data.labels))]
+            for region in data.regions:
+                y_data.append(region.spectra)
+                mapX = region.mapX
+                mapY = region.mapY
+                map_region = np.full_like(mapX, region.title, dtype=object)
+                meta_region = np.column_stack((mapX, mapY, map_region))
+                meta_data.append(meta_region.astype(object))
+            y_data = np.vstack(y_data)
+            meta_data = np.vstack(meta_data)
+
         elif type(data) == opusFC.ImageDataReturn:
             metas.extend([ContinuousVariable.make('map_x'),
                           ContinuousVariable.make('map_y')])

--- a/orangecontrib/infrared/data.py
+++ b/orangecontrib/infrared/data.py
@@ -167,7 +167,26 @@ class OPUSReader(FileFormat):
         y_data = None
         meta_data = None
 
-        if dim == '3D':
+        if dim == '3D' and hasattr(data, 'regions'):
+            y_data = []
+            meta_data = []
+            metas.extend([ContinuousVariable.make('map_x'),
+                          ContinuousVariable.make('map_y'),
+                          StringVariable.make('map_region'),
+                          TimeVariable.make('start_time')])
+            for region in data.regions:
+                y_data.append(region['spectra'])
+                mapX = region['mapX']
+                mapY = region['mapY']
+                map_region = np.full_like(mapX, region['title'], dtype=object)
+                start_time = region['start_time']
+                meta_region = np.column_stack((mapX, mapY,
+                                               map_region, start_time))
+                meta_data.append(meta_region.astype(object))
+            y_data = np.vstack(y_data)
+            meta_data = np.vstack(meta_data)
+
+        elif dim == '3D':
             metas.extend([ContinuousVariable.make('map_x'),
                           ContinuousVariable.make('map_y')])
 

--- a/orangecontrib/infrared/data.py
+++ b/orangecontrib/infrared/data.py
@@ -238,6 +238,15 @@ class OPUSReader(FileFormat):
                     y_data = np.vstack((y_data, data_3D[i]))
                     meta_data = np.vstack((meta_data, coord))
 
+        elif type(data) == opusFC.TimeResolvedTRCDataReturn:
+            y_data = data.traces
+
+        elif type(data) == opusFC.TimeResolvedDataReturn:
+            metas.extend([ContinuousVariable.make('z')])
+
+            y_data = data.spectra
+            meta_data = data.z
+
         elif type(data) == opusFC.SingleDataReturn:
             y_data = data.y[None,:]
 

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ if __name__ == '__main__':
             'Orange3>=3.3.12',
             'scipy>=0.14.0',
             'spectral>=0.18',
-            'opusFC>=1.1.0a9',
+            'opusFC>=1.1.0',
             'serverfiles>=0.2',
             'AnyQt>=0.0.6',
             'pyqtgraph>=0.10.0',

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ if __name__ == '__main__':
             'Orange3>=3.3.12',
             'scipy>=0.14.0',
             'spectral>=0.18',
-            'opusFC>=1.1.0a6',
+            'opusFC>=1.1.0a8',
             'serverfiles>=0.2',
             'AnyQt>=0.0.6',
             'pyqtgraph>=0.10.0',

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ if __name__ == '__main__':
             'Orange3>=3.3.12',
             'scipy>=0.14.0',
             'spectral>=0.18',
-            'opusFC>=1.0.0b1',
+            'opusFC>=1.1.0a6',
             'serverfiles>=0.2',
             'AnyQt>=0.0.6',
             'pyqtgraph>=0.10.0',

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ if __name__ == '__main__':
             'Orange3>=3.3.12',
             'scipy>=0.14.0',
             'spectral>=0.18',
-            'opusFC>=1.1.0a8',
+            'opusFC>=1.1.0a9',
             'serverfiles>=0.2',
             'AnyQt>=0.0.6',
             'pyqtgraph>=0.10.0',


### PR DESCRIPTION
This PR adds support for OpusFC 1.1.0 including:
 - multiregion 3D map files
 - time-resolved 3D files
 
Other changes:
 - Direct data structure matching using return Object type (instead of guessing)
 - Simplification of parameter reading code, including a fix to a previously unused code path.

@markotoplak it would be great if we could get a small release with this change for our mapping file users.