### PR TITLE
[RFC] Fix vector normalize

### DIFF
--- a/orangecontrib/infrared/preprocess.py
+++ b/orangecontrib/infrared/preprocess.py
@@ -272,22 +272,11 @@ class _NormalizeCommon:
         else:
             y_s = data.X
 
-        if self.method == Normalize.MinMax:
-            data.X /= nanmax(np.abs(y_s), axis=1).reshape((-1,1))
-        elif self.method == Normalize.MeanOffset:
-            # zero offset correction applies to entire spectrum, regardless of limits
-            y_offsets = nanmean(data.X, axis=1).reshape((-1,1))
-            data.X -= y_offsets
-        elif self.method == Normalize.Vector:
+        if self.method == Normalize.Vector:
             data.X = sknormalize(data.X, norm='l2', axis=1)
-        elif self.method == Normalize.MeanVector:
-            # zero offset correction applies to entire spectrum, regardless of limits
-            # TODO refactor methods into separate functions
-            y_offsets = nanmean(data.X, axis=1).reshape((-1,1))
-            data.X -= y_offsets
-            data.X = sknormalize(data.X, norm='l2', axis=1)
-        elif self.method == Normalize.Offset:
-            data.X -= nanmin(y_s, axis=1).reshape((-1,1))
+        elif self.method == Normalize.Area:
+            # Not implemented yet
+            pass
         elif self.method == Normalize.Attribute:
             # attr normalization applies to entire spectrum, regardless of limits
             # meta indices are -ve and start at -1
@@ -300,9 +289,9 @@ class _NormalizeCommon:
 
 class Normalize(Preprocess):
     # Normalization methods
-    MinMax, Vector, Offset, Attribute, MeanVector, MeanOffset = 0, 1, 2, 3, 4, 5
+    Vector, Area, Attribute = 0, 1, 2
 
-    def __init__(self, method=MinMax, lower=float, upper=float, limits=0, attr=None):
+    def __init__(self, method=Vector, lower=float, upper=float, limits=0, attr=None):
         self.method = method
         self.lower = lower
         self.upper = upper

--- a/orangecontrib/infrared/preprocess.py
+++ b/orangecontrib/infrared/preprocess.py
@@ -259,9 +259,7 @@ class _NormalizeCommon:
         if data.domain != self.domain:
             data = data.from_table(self.domain, data)
 
-        x = getx(data)
-
-        if data.X.shape[0] is 0:
+        if data.X.shape[0] == 0:
             return data.X
         data = data.copy()
 

--- a/orangecontrib/infrared/preprocess.py
+++ b/orangecontrib/infrared/preprocess.py
@@ -261,6 +261,8 @@ class _NormalizeCommon:
 
         x = getx(data)
 
+        if data.X.shape[0] is 0:
+            return data.X
         data = data.copy()
 
         if self.method == Normalize.Vector:

--- a/orangecontrib/infrared/preprocess.py
+++ b/orangecontrib/infrared/preprocess.py
@@ -266,7 +266,7 @@ class _NormalizeCommon:
         data = data.copy()
 
         if self.method == Normalize.Vector:
-            data.X = sknormalize(data.X, norm='l2', axis=1)
+            data.X = sknormalize(data.X, norm='l2', axis=1, copy=False)
         elif self.method == Normalize.Area:
             norm_data = Integrate(method=self.int_method,
                                   limits=[[self.lower, self.upper]])(data)

--- a/orangecontrib/infrared/tests/test_preprocess.py
+++ b/orangecontrib/infrared/tests/test_preprocess.py
@@ -156,65 +156,37 @@ class TestRubberbandBaseline(unittest.TestCase):
 
 class TestNormalize(unittest.TestCase):
 
-    def test_minmax(self):
-        data = Orange.data.Table([[2, 1, 2, 2, 3]])
-        p = Normalize(method=Normalize.MinMax)(data)
-        np.testing.assert_equal(p.X, data.X/3)
-        p = Normalize(method=Normalize.MinMax, limits=True, lower=0, upper=4)(data)
-        np.testing.assert_equal(p.X, data.X / 3)
-        p = Normalize(method=Normalize.MinMax, limits=True, lower=0, upper=3)(data)
-        np.testing.assert_equal(p.X, data.X/2)
-
-    def test_offset(self):
-        data = Orange.data.Table([[2, 1, 2, 2, 3]])
-        p = Normalize(method=Normalize.Offset)(data)
-        np.testing.assert_equal(p.X, data.X - 1)
-        p = Normalize(method=Normalize.Offset, limits=True, lower=0, upper=4)(data)
-        np.testing.assert_equal(p.X, data.X - 1)
-        p = Normalize(method=Normalize.Offset, limits=True, lower=2, upper=4)(data)
-        np.testing.assert_equal(p.X, data.X - 2)
-
-    def test_meanoffset(self):
-        data = Orange.data.Table([[2, 1, 2, 2, 3]])
-        p = Normalize(method=Normalize.MeanOffset)(data)
-        np.testing.assert_equal(p.X, data.X - 2)
-        p = Normalize(method=Normalize.MeanOffset, limits=True, lower=0, upper=4)(data)
-        np.testing.assert_equal(p.X, data.X - 2)
-        p = Normalize(method=Normalize.MeanOffset, limits=True, lower=2, upper=4)(data)
-        np.testing.assert_equal(p.X, data.X - 2)
-
-    def test_vector(self):
+    def test_vector_norm(self):
         data = Orange.data.Table([[2, 1, 2, 2, 3]])
         p = Normalize(method=Normalize.Vector)(data)
         q = data.X / np.sqrt((data.X * data.X).sum(axis=1))
         np.testing.assert_equal(p.X, q)
-        p = Normalize(method=Normalize.Vector, limits=True, lower=0, upper=4)(data)
+        p = Normalize(method=Normalize.Vector, lower=0, upper=4)(data)
         np.testing.assert_equal(p.X, q)
-        p = Normalize(method=Normalize.Vector, limits=True, lower=0, upper=2)(data)
+        p = Normalize(method=Normalize.Vector, lower=0, upper=2)(data)
         np.testing.assert_equal(p.X, q)
 
-    def test_meanvector(self):
+    def test_area_norm(self):
         data = Orange.data.Table([[2, 1, 2, 2, 3]])
-        p = Normalize(method=Normalize.MeanVector)(data)
-        offset = Normalize(method=Normalize.MeanOffset)(data)
-        q = offset.X / np.sqrt((offset.X * offset.X).sum(axis=1))
-        np.testing.assert_equal(p.X, q)
-        p = Normalize(method=Normalize.MeanVector, limits=True, lower=0, upper=4)(data)
-        np.testing.assert_equal(p.X, q)
-        p = Normalize(method=Normalize.MeanVector, limits=True, lower=0, upper=2)(data)
-        np.testing.assert_equal(p.X, q)
+        p = Normalize(method=Normalize.Area, int_method=Integrate.PeakMax, lower=0, upper=4)(data)
+        np.testing.assert_equal(p.X, data.X / 3)
+        p = Normalize(method=Normalize.Area, int_method=Integrate.Simple, lower=0, upper=4)(data)
+        np.testing.assert_equal(p.X, data.X / 7.5)
+        p = Normalize(method=Normalize.Area, int_method=Integrate.Simple, lower=0, upper=2)(data)
+        q = Integrate(method=Integrate.Simple, limits=[[0, 2]])(p)
+        np.testing.assert_equal(q.X, np.ones_like(q.X))
 
-    def test_attribute(self):
+    def test_attribute_norm(self):
         data = Orange.data.Table([[2, 1, 2, 2, 3]], metas=[[2]])
         p = Normalize(method=Normalize.Attribute)(data)
         np.testing.assert_equal(p.X, data.X)
         p = Normalize(method=Normalize.Attribute, attr=data.domain.metas[0])(data)
         np.testing.assert_equal(p.X, data.X / 2)
         p = Normalize(method=Normalize.Attribute, attr=data.domain.metas[0],
-                limits=True, lower=0, upper=4)(data)
+                lower=0, upper=4)(data)
         np.testing.assert_equal(p.X, data.X / 2)
         p = Normalize(method=Normalize.Attribute, attr=data.domain.metas[0],
-                limits=True, lower=2, upper=4)(data)
+                lower=2, upper=4)(data)
         np.testing.assert_equal(p.X, data.X / 2)
 
 

--- a/orangecontrib/infrared/tests/test_preprocess.py
+++ b/orangecontrib/infrared/tests/test_preprocess.py
@@ -162,6 +162,8 @@ class TestNormalize(unittest.TestCase):
         np.testing.assert_equal(p.X, data.X/3)
         p = Normalize(method=Normalize.MinMax, limits=True, lower=0, upper=4)(data)
         np.testing.assert_equal(p.X, data.X / 3)
+        p = Normalize(method=Normalize.MinMax, limits=True, lower=0, upper=3)(data)
+        np.testing.assert_equal(p.X, data.X/2)
 
     def test_offset(self):
         data = Orange.data.Table([[2, 1, 2, 2, 3]])
@@ -169,6 +171,51 @@ class TestNormalize(unittest.TestCase):
         np.testing.assert_equal(p.X, data.X - 1)
         p = Normalize(method=Normalize.Offset, limits=True, lower=0, upper=4)(data)
         np.testing.assert_equal(p.X, data.X - 1)
+        p = Normalize(method=Normalize.Offset, limits=True, lower=2, upper=4)(data)
+        np.testing.assert_equal(p.X, data.X - 2)
+
+    def test_meanoffset(self):
+        data = Orange.data.Table([[2, 1, 2, 2, 3]])
+        p = Normalize(method=Normalize.MeanOffset)(data)
+        np.testing.assert_equal(p.X, data.X - 2)
+        p = Normalize(method=Normalize.MeanOffset, limits=True, lower=0, upper=4)(data)
+        np.testing.assert_equal(p.X, data.X - 2)
+        p = Normalize(method=Normalize.MeanOffset, limits=True, lower=2, upper=4)(data)
+        np.testing.assert_equal(p.X, data.X - 2)
+
+    def test_vector(self):
+        data = Orange.data.Table([[2, 1, 2, 2, 3]])
+        p = Normalize(method=Normalize.Vector)(data)
+        q = data.X / np.sqrt((data.X * data.X).sum(axis=1))
+        np.testing.assert_equal(p.X, q)
+        p = Normalize(method=Normalize.Vector, limits=True, lower=0, upper=4)(data)
+        np.testing.assert_equal(p.X, q)
+        p = Normalize(method=Normalize.Vector, limits=True, lower=0, upper=2)(data)
+        np.testing.assert_equal(p.X, q)
+
+    def test_meanvector(self):
+        data = Orange.data.Table([[2, 1, 2, 2, 3]])
+        p = Normalize(method=Normalize.MeanVector)(data)
+        offset = Normalize(method=Normalize.MeanOffset)(data)
+        q = offset.X / np.sqrt((offset.X * offset.X).sum(axis=1))
+        np.testing.assert_equal(p.X, q)
+        p = Normalize(method=Normalize.MeanVector, limits=True, lower=0, upper=4)(data)
+        np.testing.assert_equal(p.X, q)
+        p = Normalize(method=Normalize.MeanVector, limits=True, lower=0, upper=2)(data)
+        np.testing.assert_equal(p.X, q)
+
+    def test_attribute(self):
+        data = Orange.data.Table([[2, 1, 2, 2, 3]], metas=[[2]])
+        p = Normalize(method=Normalize.Attribute)(data)
+        np.testing.assert_equal(p.X, data.X)
+        p = Normalize(method=Normalize.Attribute, attr=data.domain.metas[0])(data)
+        np.testing.assert_equal(p.X, data.X / 2)
+        p = Normalize(method=Normalize.Attribute, attr=data.domain.metas[0],
+                limits=True, lower=0, upper=4)(data)
+        np.testing.assert_equal(p.X, data.X / 2)
+        p = Normalize(method=Normalize.Attribute, attr=data.domain.metas[0],
+                limits=True, lower=2, upper=4)(data)
+        np.testing.assert_equal(p.X, data.X / 2)
 
 
 class TestCommon(unittest.TestCase):

--- a/orangecontrib/infrared/widgets/owpreproc.py
+++ b/orangecontrib/infrared/widgets/owpreproc.py
@@ -666,19 +666,21 @@ class NormalizeEditor(BaseEditor):
 
         model = VariableListModel()
         model.wrap(self.attrs)
-        self.attrcb = QComboBox(visible=False, maximumWidth=100)
+        self.attrform = QFormLayout()
+        self.attrcb = QComboBox(enabled=False)
         self.attrcb.setModel(model)
+        self.attrform.addRow("Normalize to", self.attrcb)
 
         self.areaform = QFormLayout()
-        self.int_method_cb = QComboBox()
+        self.int_method_cb = QComboBox(enabled=False)
         self.int_method_cb.addItems(IntegrateEditor.Integrators)
         minf,maxf = -sys.float_info.max, sys.float_info.max
         self.lspin = SetXDoubleSpinBox(
             minimum=minf, maximum=maxf, singleStep=0.5,
-            value=self.lower)
+            value=self.lower, enabled=False)
         self.uspin = SetXDoubleSpinBox(
             minimum=minf, maximum=maxf, singleStep=0.5,
-            value=self.upper)
+            value=self.upper, enabled=False)
         self.areaform.addRow("Normalize to", self.int_method_cb)
         self.areaform.addRow("Lower limit", self.lspin)
         self.areaform.addRow("Upper limit", self.uspin)
@@ -692,7 +694,7 @@ class NormalizeEditor(BaseEditor):
                         )
             layout.addWidget(rb)
             if method is Normalize.Attribute:
-                layout.addWidget(self.attrcb)
+                layout.addLayout(self.attrform)
             elif method is Normalize.Area:
                 layout.addLayout(self.areaform)
             group.addButton(rb, method)
@@ -753,10 +755,14 @@ class NormalizeEditor(BaseEditor):
             self.__method = method
             b = self.__group.button(method)
             b.setChecked(True)
+            for widget in [self.attrcb, self.int_method_cb, self.lspin, self.uspin]:
+                widget.setEnabled(False)
             if method is Normalize.Attribute:
-                self.attrcb.setVisible(True)
-            else:
-                self.attrcb.setVisible(False)
+                self.attrcb.setEnabled(True)
+            elif method is Normalize.Area:
+                self.int_method_cb.setEnabled(True)
+                self.lspin.setEnabled(True)
+                self.uspin.setEnabled(True)
             self.activateOptions()
             self.changed.emit()
 

--- a/orangecontrib/infrared/widgets/owpreproc.py
+++ b/orangecontrib/infrared/widgets/owpreproc.py
@@ -650,7 +650,9 @@ class NormalizeEditor(BaseEditor):
     Normalizers = [
         ("Min-Max Scaling", Normalize.MinMax),
         ("Vector Normalization", Normalize.Vector),
+        ("Mean-centered Vector Normalization", Normalize.MeanVector),
         ("Offset Correction", Normalize.Offset),
+        ("Mean-centered Offset Correction", Normalize.MeanOffset),
         ("Attribute Normalization", Normalize.Attribute)]
 
 

--- a/orangecontrib/infrared/widgets/owpreproc.py
+++ b/orangecontrib/infrared/widgets/owpreproc.py
@@ -723,7 +723,9 @@ class NormalizeEditor(BaseEditor):
         if self.__method == Normalize.Area:
             if self.lline not in self.parent_widget.curveplot.markings:
                 self.parent_widget.curveplot.add_marking(self.lline)
-            if self.uline not in self.parent_widget.curveplot.markings:
+            if (self.uline not in self.parent_widget.curveplot.markings
+                    and IntegrateEditor.Integrators_classes[self.int_method]
+                        is not Integrate.PeakAt):
                 self.parent_widget.curveplot.add_marking(self.uline)
 
     def setParameters(self, params):
@@ -755,6 +757,7 @@ class NormalizeEditor(BaseEditor):
                 self.attrcb.setVisible(True)
             else:
                 self.attrcb.setVisible(False)
+            self.activateOptions()
             self.changed.emit()
 
     def setL(self, lower, user=True):
@@ -778,6 +781,9 @@ class NormalizeEditor(BaseEditor):
             self.changed.emit()
 
     def reorderLimits(self):
+        if (IntegrateEditor.Integrators_classes[self.int_method]
+                is Integrate.PeakAt):
+            self.upper = self.lower + 10
         limits = [self.lower, self.upper]
         self.lower, self.upper = min(limits), max(limits)
         self.lspin.setValue(self.lower)
@@ -789,6 +795,7 @@ class NormalizeEditor(BaseEditor):
     def setinttype(self):
         if self.int_method != self.int_method_cb.currentIndex():
             self.int_method = self.int_method_cb.currentIndex()
+            self.reorderLimits()
             self.activateOptions()
             self.changed.emit()
 
@@ -1138,8 +1145,8 @@ PREPROCESSORS = [
         RubberbandBaselineEditor
     ),
     PreprocessAction(
-        "Normalization", "orangecontrib.infrared.normalize", "Normalization",
-        Description("Normalization",
+        "Normalize Spectra", "orangecontrib.infrared.normalize", "Normalize Spectra",
+        Description("Normalize Spectra",
         icon_path("Normalize.svg")),
         NormalizeEditor
     ),


### PR DESCRIPTION
Looking for some feedback, not quite ready to merge.

### Rationale
Current vector normalization routine does not return the correct value.

### Changes
Replaced custom implementation with `sklearn.preprocessing.normalize`, since it
(a) handles sparse data, (b) is faster and (c) minimizes unnecessary data copies.

In addition, "OPUS-style" vector normalization includes mean-centering the spectra
_before_ vector normalization, which is not what most users will expect, so I broke that out. Mean-centering is also useful for some data treatment workflows.

### Interested in feedback on 
  1. Naming of the different normalization routines
  2. Refactoring the normalization routines into separate functions. Specifically,
      is there an example best-practice I could follow, there are so many different
      approaches in our/Orange codebase. I was thinking of following the Integrate preprocessor.
  3. `Normalize.Vector` and `Normalize.MeanVector` fail `test_no_samples` since 
      `sklean.preprocessing.normalize` can't accept inputs with shape (0, n)

Thanks!