### PR TITLE
OWCurves: showing_sample should be called after update_view()

### DIFF
--- a/orangecontrib/infrared/tests/test_owcurves.py
+++ b/orangecontrib/infrared/tests/test_owcurves.py
@@ -152,6 +152,14 @@ class TestOWCurves(WidgetTest):
         self.send_signal("Data", self.iris)
         self.assertFalse(self.widget.Warning.no_x.is_shown())
 
+    def test_information(self):
+        self.send_signal("Data", self.iris[:100])
+        self.assertFalse(self.widget.Information.showing_sample.is_shown())
+        self.send_signal("Data", self.iris)
+        self.assertTrue(self.widget.Information.showing_sample.is_shown())
+        self.send_signal("Data", self.iris[:100])
+        self.assertFalse(self.widget.Information.showing_sample.is_shown())
+
     def test_handle_floatname(self):
         self.send_signal("Data", self.collagen)
         x, cys = self.widget.curveplot.curves[0]

--- a/orangecontrib/infrared/widgets/owcurves.py
+++ b/orangecontrib/infrared/widgets/owcurves.py
@@ -1048,13 +1048,13 @@ class OWCurves(OWWidget):
         self.Warning.no_x.clear()
         self.closeContext()
         self.curveplot.set_data(data)
+        self.openContext(data)
+        self.curveplot.update_view()
         if data is not None and not len(self.curveplot.data_x):
             self.Warning.no_x()
         if self.curveplot.sampled_indices \
                 and len(self.curveplot.sampled_indices) != len(self.curveplot.data):
             self.Information.showing_sample(len(self.curveplot.sampled_indices), len(data))
-        self.openContext(data)
-        self.curveplot.update_view()
         self.selection_changed()
 
     def set_subset(self, data):


### PR DESCRIPTION
self.curveplot.sample_indices isn't populated until update_view() is called. 

Also I don't think the other warning works either, if I feed `titanic.dat` to curves it doesn't trigger.