### PR TITLE
Files: faster multiple file loading for some formats

### DIFF
--- a/orangecontrib/infrared/data.py
+++ b/orangecontrib/infrared/data.py
@@ -468,7 +468,7 @@ class OPUSReader(FileFormat):
         return table
 
 
-class SpectralFileFormat(FileFormat):
+class SpectralFileFormat:
 
     def read_spectra(self):
         """ Fast reading of spectra. Return spectral information
@@ -482,8 +482,13 @@ class SpectralFileFormat(FileFormat):
         """
         pass
 
+    def read(self):
+        domvals, data, _ = self.read_spectra()
+        domain = Orange.data.Domain([Orange.data.ContinuousVariable.make("%f" % f) for f in domvals], None)
+        return Orange.data.Table(domain, data)
 
-class SPAReader(SpectralFileFormat):
+
+class SPAReader(FileFormat, SpectralFileFormat):
     #based on code by Zack Gainsforth
 
     EXTENSIONS = (".spa", ".SPA", ".srs")
@@ -552,11 +557,6 @@ class SPAReader(SpectralFileFormat):
 
         data = np.array([data])
         return domvals, data, None
-
-    def read(self):
-        domvals, data, _ = self.read_spectra()
-        domain = Orange.data.Domain([Orange.data.ContinuousVariable.make("%f" % f) for f in domvals], None)
-        return Orange.data.Table(domain, data)
 
 
 class GSFReader(FileFormat):

--- a/orangecontrib/infrared/tests/test_owfiles.py
+++ b/orangecontrib/infrared/tests/test_owfiles.py
@@ -1,10 +1,25 @@
 import unittest
 
 import AnyQt
+import numpy as np
 
 from Orange.widgets.tests.base import WidgetTest
-from orangecontrib.infrared.widgets.owfiles import OWFiles
+from orangecontrib.infrared.widgets.owfiles import OWFiles, numpy_union_keep_order
 from Orange.data import FileFormat, dataset_dirs, Table
+
+
+class TestOWFilesAuxiliary(unittest.TestCase):
+
+    def test_numpy_union(self):
+        A = np.array([2, 1, 3])
+        B = np.array([1, 3])
+        np.testing.assert_equal(numpy_union_keep_order(A, B), [2, 1, 3])
+        B = np.array([])
+        np.testing.assert_equal(numpy_union_keep_order(A, B), [2, 1, 3])
+        B = np.array([5, 4, 6, 3])
+        np.testing.assert_equal(numpy_union_keep_order(A, B), [2, 1, 3, 5, 4, 6])
+        A = np.array([])
+        np.testing.assert_equal(numpy_union_keep_order(A, B), [5, 4, 6, 3])
 
 
 class TestOWFiles(WidgetTest):

--- a/orangecontrib/infrared/tests/test_owfiles.py
+++ b/orangecontrib/infrared/tests/test_owfiles.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 import AnyQt
 import numpy as np
@@ -6,6 +7,9 @@ import numpy as np
 from Orange.widgets.tests.base import WidgetTest
 from orangecontrib.infrared.widgets.owfiles import OWFiles, numpy_union_keep_order
 from Orange.data import FileFormat, dataset_dirs, Table
+
+from orangecontrib.infrared.data import SPAReader
+from Orange.data.io import TabReader
 
 
 class TestOWFilesAuxiliary(unittest.TestCase):
@@ -85,3 +89,36 @@ class TestOWFiles(WidgetTest):
         self.load_files("peach_juice.0")
         self.widget.sheet_combo.setCurrentIndex(1)
         self.widget.select_sheet()
+
+    def test_special_spectral_reading(self):
+
+        class CountTabReader(TabReader):
+            read_count = 0
+
+            def read(self):
+                type(self).read_count += 1
+                return super().read()
+
+        class CountSPAReader(SPAReader):
+            read_count = 0
+            read_spectra_count = 0
+
+            def read(self):
+                type(self).read_count += 1
+                return super().read()
+
+            def read_spectra(self):
+                type(self).read_spectra_count += 1
+                return super().read_spectra()
+
+        # can not patch readers directly as they are already in registry
+        with patch.object(FileFormat, "registry", {"TabReader": CountTabReader,
+                                                   "SPAReader": CountSPAReader}):
+            # clear LRU cache so that new classes get use
+            FileFormat._ext_to_attr_if_attr2.cache_clear()
+            self.load_files("titanic.tab", "sample1.spa")
+            self.assertEqual(CountSPAReader.read_count, 0)
+            self.assertEqual(CountSPAReader.read_spectra_count, 1)
+            self.assertEqual(CountTabReader.read_count, 1)
+            # clear cache so the new classes are thrown out
+            FileFormat._ext_to_attr_if_attr2.cache_clear()

--- a/orangecontrib/infrared/widgets/owfiles.py
+++ b/orangecontrib/infrared/widgets/owfiles.py
@@ -35,17 +35,31 @@ def domain_union(A, B):
     return union
 
 
+def numpy_union_keep_order(A, B):
+    """ Union of A and B. Elements not in A are
+    added in the same order as in B."""
+    # sorted list of elements missing in A
+    to_add = np.setdiff1d(B, A)
+
+    # find indices of new elements in the sorted array
+    orig_sind = np.argsort(B)
+    indices = np.searchsorted(B, to_add, sorter=orig_sind)
+
+    # take the missing elements in the correct order
+    to_add = B[sorted(orig_sind[indices])]
+
+    return np.concatenate((A, to_add))
+
+
 def domain_union_for_spectra(tables):
     """
     Works with tables of spectra-specific 3-tuples
     """
     domains = [t.domain if isinstance(t, Orange.data.Table) else t[2].domain for t in tables]
-    xss = [t[0] for t in tables if not isinstance(t, Orange.data.Table)]
-
     domain = reduce(domain_union, domains, Orange.data.Domain(attributes=[]))
 
-    # TODO rewrite so that it keeps similar order
-    xs = reduce(np.union1d, xss, np.array([]))
+    xss = [t[0] for t in tables if not isinstance(t, Orange.data.Table)]
+    xs = reduce(numpy_union_keep_order, xss, np.array([]))
 
     xsset = set("%f" % f for f in xs)  # future attribute names
     attributes_name_set = set(a.name for a in domain.attributes)

--- a/orangecontrib/infrared/widgets/owfiles.py
+++ b/orangecontrib/infrared/widgets/owfiles.py
@@ -9,6 +9,7 @@ import numpy as np
 
 import Orange
 import orangecontrib.infrared
+from orangecontrib.infrared.data import SpectralFileFormat, getx
 from Orange.data.io import FileFormat
 from Orange.widgets import widget, gui
 import Orange.widgets.data.owfile
@@ -34,23 +35,59 @@ def domain_union(A, B):
     return union
 
 
+def domain_union_for_spectra(tables):
+    """
+    Works with tables of spectra-specific 3-tuples
+    """
+    domains = [t.domain if isinstance(t, Orange.data.Table) else t[2].domain for t in tables]
+    xss = [t[0] for t in tables if not isinstance(t, Orange.data.Table)]
+
+    domain = reduce(domain_union, domains, Orange.data.Domain(attributes=[]))
+
+    # TODO rewrite so that it keeps similar order
+    xs = reduce(np.union1d, xss, np.array([]))
+
+    xsset = set("%f" % f for f in xs)  # future attribute names
+    attributes_name_set = set(a.name for a in domain.attributes)
+    if xsset & attributes_name_set:
+        # TODO test
+        raise RuntimeError("Mixing files of different times with overlapping domain values is not supported")
+
+    return domain, xs
+
+
 def concatenate_data(tables, filenames, label):
-    domain = reduce(domain_union,
-                    (table.domain for table in tables))
+    domain, xs = domain_union_for_spectra(tables)
+    ntables = [(table if isinstance(table, Orange.data.Table) else table[2]).transform(domain)
+              for table in tables]
+    data = type(ntables[0]).concatenate(ntables, axis=0)
     source_var = Orange.data.StringVariable.make("Filename")
     label_var = Orange.data.StringVariable.make("Label")
-    domain = Orange.data.Domain(domain.attributes, domain.class_vars,
+
+    # add other variables
+    xs_atts = tuple([Orange.data.ContinuousVariable.make("%f" % f) for f in xs])
+    domain = Orange.data.Domain(xs_atts + domain.attributes, domain.class_vars,
                                 domain.metas + (source_var, label_var))
-    tables = [Orange.data.Table.from_table(domain, table)
-              for table in tables]
-    data = type(tables[0]).concatenate(tables, axis=0)
+    data = data.transform(domain)
+
+    #fill in spectral data
+    xs_sind = np.argsort(xs)
+    xs_sorted = xs[xs_sind]
+    pos = 0
+    for table in tables:
+        t = table if isinstance(table, Orange.data.Table) else table[2]
+        if not isinstance(table, Orange.data.Table):
+            indices = xs_sind[np.searchsorted(xs_sorted, table[0])]
+            data.X[pos:pos+len(t), indices] = table[1]
+        pos += len(t)
+
     data[:, source_var] = np.array(list(
         chain(*(repeat(fn, len(table))
-                for fn, table in zip(filenames, tables)))
+                for fn, table in zip(filenames, ntables)))
     )).reshape(-1, 1)
     data[:, label_var] = np.array(list(
         chain(*(repeat(label, len(table))
-                for fn, table in zip(filenames, tables)))
+                for fn, table in zip(filenames, ntables)))
     )).reshape(-1, 1)
     return data
 
@@ -255,15 +292,21 @@ class OWFiles(Orange.widgets.data.owfile.OWFile, RecentPathsWidgetMixin):
         data_list = []
         fnok_list = []
 
+        empty_domain = Orange.data.Domain(attributes=[])
         for fn in fns:
             reader = FileFormat.get_reader(fn)
-
             errors = []
             with catch_warnings(record=True) as warnings:
                 try:
                     if self.sheet in reader.sheets:
                         reader.select_sheet(self.sheet)
-                    data_list.append(reader.read())
+                    if isinstance(reader, SpectralFileFormat):
+                        xs, vals, additional = reader.read_spectra()
+                        if additional is None:
+                            additional = Orange.data.Table.from_domain(empty_domain, n_rows=len(vals))
+                        data_list.append((xs, vals, additional))
+                    else:
+                        data_list.append(reader.read())
                     fnok_list.append(fn)
                 except Exception as ex:
                     errors.append("An error occurred:")


### PR DESCRIPTION
The files widget can now load many small files in spa, Envi, hdf5_hermes, and Omnic map format faster, because it does not construct a table for each file.

With Orange master I can now open 10000 1-spectra spa files in 10 seconds.