### PR TITLE
Spectra: adapt selected_indices for Orange master

### DIFF
--- a/orangecontrib/infrared/tests/test_owcurves.py
+++ b/orangecontrib/infrared/tests/test_owcurves.py
@@ -294,7 +294,9 @@ class TestOWCurves(WidgetTest):
 
     def test_open_selection(self):
         # saved selection in the file should be reloaded
-        self.widget.curveplot.selected_indices = set([0])
+        self.widget = self.create_widget(
+            OWCurves, stored_settings={"curveplot": {"selected_indices": set([0])}}
+        )
         self.send_signal("Data", self.iris)
         out = self.get_output("Selection")
         self.assertEqual(out[0], self.iris[0])

--- a/orangecontrib/infrared/widgets/owcurves.py
+++ b/orangecontrib/infrared/widgets/owcurves.py
@@ -420,6 +420,9 @@ class CurvePlot(QWidget, OWComponent):
         self.subset = None  # current subset input, an array of indices
         self.subset_indices = None  # boolean index array with indices in self.data
 
+        # Remember the saved state to restore with the first open file
+        self.__pending_selection_restore = self.selected_indices
+
         self.plotview = pg.PlotWidget(background="w", viewBox=InteractiveViewBoxC(self))
         self.plot = self.plotview.getPlotItem()
         self.plot.setDownsampling(auto=True, mode="peak")
@@ -1090,6 +1093,9 @@ class CurvePlot(QWidget, OWComponent):
             self.plot.vb.autoRange()
 
     def set_data(self, data, auto_update=True):
+        # after 20171023 selected indices are not reset on close context
+        self.selected_indices = None
+
         if not self.selected_indices:  # either None or previously saved empty set
             self.selected_indices = set()
         if self.data is data:
@@ -1100,6 +1106,12 @@ class CurvePlot(QWidget, OWComponent):
             else:
                 self.rescale_next = True
             self.data = data
+
+            # restore pending selection from saved data
+            if self.__pending_selection_restore is not None:
+                self.selected_indices = self.__pending_selection_restore
+                self.__pending_selection_restore = None
+
             if self.select_at_least_1:
                 self.make_selection([], add=True)  # make selection valid
             # get and sort input data


### PR DESCRIPTION
Orange was changed so that schema_only settings are not reset
when Orange closes context.