### PR TITLE
owspectra: call make_selection in set_data after setting self.data_x (when self.select_at_least_1 is True)

### DIFF
--- a/orangecontrib/infrared/widgets/owspectra.py
+++ b/orangecontrib/infrared/widgets/owspectra.py
@@ -1150,14 +1150,14 @@ class CurvePlot(QWidget, OWComponent, SelectionGroupMixin):
 
             self.restore_selection_settings()
 
-            if self.select_at_least_1:
-                self.make_selection([], add=True)  # make selection valid
             # get and sort input data
             x = getx(self.data)
             xsind = np.argsort(x)
             self.data_x = x[xsind]
             self.data_xsind = xsind
             self._set_subset_indices()  # refresh subset indices according to the current subset
+            if self.select_at_least_1:
+                self.make_selection([], add=True)  # make selection valid
         else:
             self.clear_data()
         if auto_update:


### PR DESCRIPTION
This was a fun one to track down. 

When you load data on a owintegrate widget, `self.curveplot.select_at_least_1` is set to `True`. This causes the `make_selection` function to be called in `owcurves.set_data` _before_ `self.data_x` is defined. The function `make_selection` tries to add a curve to the plot with x = None or [[0]] resulting in "Exception: Plot data must be 1D ndarray." from pyqtgraph (see traceback below).

For reasons unclear to me, this bug is not triggered when you run owintegrate by itself (as __main__), so I haven't included a test as I feel that I don't fully understand the error.

Traceback:

```
Traceback (most recent call last):
  File "C:\Users\reads\AppData\Local\Continuum\Miniconda3-x86_64\envs\orange3\lib\site-packages\Orange\canvas\scheme\widgetsscheme.py", line 832, in process_signals_for_widget
    handler(*args)
  File "C:\Users\reads\AppData\Local\Continuum\Miniconda3-x86_64\envs\orange3\lib\site-packages\Orange\widgets\utils\sql.py", line 31, in new_f
    return f(widget, data, *args, **kwargs)
  File "H:\src\orange-infrared\orangecontrib\infrared\widgets\owpreproc.py", line 1461, in set_data
    self.show_preview(True)
  File "H:\src\orange-infrared\orangecontrib\infrared\widgets\owintegrate.py", line 215, in show_preview
    super().show_preview(False)
  File "H:\src\orange-infrared\orangecontrib\infrared\widgets\owpreproc.py", line 1346, in show_preview
    self.curveplot.set_data(preview_data)
  File "H:\src\orange-infrared\orangecontrib\infrared\widgets\owcurves.py", line 1104, in set_data
    self.make_selection([], add=True)  # make selection valid
  File "H:\src\orange-infrared\orangecontrib\infrared\widgets\owcurves.py", line 806, in make_selection
    self.selection_changed()
  File "H:\src\orange-infrared\orangecontrib\infrared\widgets\owcurves.py", line 811, in selection_changed
    self.show_average()
  File "H:\src\orange-infrared\orangecontrib\infrared\widgets\owcurves.py", line 1076, in show_average
    self.add_curve(x, mean, pen=penc)
  File "H:\src\orange-infrared\orangecontrib\infrared\widgets\owcurves.py", line 942, in add_curve
    c = pg.PlotCurveItem(x=x, y=y, pen=pen if pen else self.pen_normal[None])
  File "C:\Users\reads\AppData\Local\Continuum\Miniconda3-x86_64\envs\orange3\lib\site-packages\pyqtgraph\graphicsItems\PlotCurveItem.py", line 73, in __init__
    self.setData(*args, **kargs)
  File "C:\Users\reads\AppData\Local\Continuum\Miniconda3-x86_64\envs\orange3\lib\site-packages\pyqtgraph\graphicsItems\PlotCurveItem.py", line 307, in setData
    self.updateData(*args, **kargs)
  File "C:\Users\reads\AppData\Local\Continuum\Miniconda3-x86_64\envs\orange3\lib\site-packages\pyqtgraph\graphicsItems\PlotCurveItem.py", line 329, in updateData
    raise Exception("Plot data must be 1D ndarray.")
Exception: Plot data must be 1D ndarray.
```