### PR TITLE
agilent: Fix XY image coordinates and tests

### DIFF
--- a/orangecontrib/spectroscopy/agilent.py
+++ b/orangecontrib/spectroscopy/agilent.py
@@ -61,7 +61,7 @@ def _get_params(f):
     Takes an open file handle and reads a preset selection of parameters
     returns in a dictionary
     """
-    STRP = b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\x10\x11\x12\x13\x14\x15\x16\x17\x18'
+    STRP = b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15\x16\x17\x18'
 
     def _get_section(dat, section):
         skip = [b'', b'\n', b'\"', b'\t', b',', b'\r',
@@ -97,6 +97,11 @@ def _get_params(f):
         val = struct.unpack("d", val_b[12:20])[0]
         return val
 
+    def _get_prop_str(dat, param):
+        part = dat.partition(bytes(param, encoding='utf8'))
+        val = part[2][:100].lstrip(STRP).split(b'\x00')[0].strip(STRP)
+        return val.decode('utf8', errors='replace')
+
     d = {}
     f.seek(0)
     dat = f.read()
@@ -105,6 +110,10 @@ def _get_params(f):
     d['FPA Pixel Size'] = _get_prop_d(dat, 'FPA Pixel Size')
     d['Rapid Stingray'] = _get_section(dat, 'Rapid Stingray')
     d['Time Stamp'] = d['Rapid Stingray']['Time Stamp']
+    try:
+        d['PixelAggregationSize'] = int(_get_prop_str(dat, 'PixelAggregationSize'))
+    except ValueError:
+        pass
 
     return d
 

--- a/orangecontrib/spectroscopy/data.py
+++ b/orangecontrib/spectroscopy/data.py
@@ -300,12 +300,12 @@ class AgilentImageReader(FileFormat, SpectralFileFormat):
             features = np.arange(X.shape[-1])
 
         try:
-            fpa_px_size = info['FPA Pixel Size']
+            px_size = info['FPA Pixel Size'] * info['PixelAggregationSize']
         except KeyError:
             # Use pixel units if FPA Pixel Size is not known
-            fpa_px_size = 1
-        x_locs = np.linspace(0, X.shape[1]*fpa_px_size, X.shape[1])
-        y_locs = np.linspace(0, X.shape[0]*fpa_px_size, X.shape[0])
+            px_size = 1
+        x_locs = np.linspace(0, X.shape[1]*px_size, X.shape[1])
+        y_locs = np.linspace(0, X.shape[0]*px_size, X.shape[0])
 
         return _spectra_from_image(X, features, x_locs, y_locs)
 
@@ -327,12 +327,12 @@ class agilentMosaicReader(FileFormat, SpectralFileFormat):
             features = np.arange(X.shape[-1])
 
         try:
-            fpa_px_size = info['FPA Pixel Size']
+            px_size = info['FPA Pixel Size'] * info['PixelAggregationSize']
         except KeyError:
             # Use pixel units if FPA Pixel Size is not known
-            fpa_px_size = 1
-        x_locs = np.linspace(0, X.shape[1]*fpa_px_size, X.shape[1])
-        y_locs = np.linspace(0, X.shape[0]*fpa_px_size, X.shape[0])
+            px_size = 1
+        x_locs = np.linspace(0, X.shape[1]*px_size, X.shape[1])
+        y_locs = np.linspace(0, X.shape[0]*px_size, X.shape[0])
 
         return _spectra_from_image(X, features, x_locs, y_locs)
 

--- a/orangecontrib/spectroscopy/data.py
+++ b/orangecontrib/spectroscopy/data.py
@@ -304,8 +304,8 @@ class AgilentImageReader(FileFormat, SpectralFileFormat):
         except KeyError:
             # Use pixel units if FPA Pixel Size is not known
             px_size = 1
-        x_locs = np.linspace(0, X.shape[1]*px_size, X.shape[1])
-        y_locs = np.linspace(0, X.shape[0]*px_size, X.shape[0])
+        x_locs = np.linspace(0, X.shape[1]*px_size, num=X.shape[1], endpoint=False)
+        y_locs = np.linspace(0, X.shape[0]*px_size, num=X.shape[0], endpoint=False)
 
         return _spectra_from_image(X, features, x_locs, y_locs)
 
@@ -331,8 +331,8 @@ class agilentMosaicReader(FileFormat, SpectralFileFormat):
         except KeyError:
             # Use pixel units if FPA Pixel Size is not known
             px_size = 1
-        x_locs = np.linspace(0, X.shape[1]*px_size, X.shape[1])
-        y_locs = np.linspace(0, X.shape[0]*px_size, X.shape[0])
+        x_locs = np.linspace(0, X.shape[1]*px_size, num=X.shape[1], endpoint=False)
+        y_locs = np.linspace(0, X.shape[0]*px_size, num=X.shape[0], endpoint=False)
 
         return _spectra_from_image(X, features, x_locs, y_locs)
 

--- a/orangecontrib/spectroscopy/tests/test_readers.py
+++ b/orangecontrib/spectroscopy/tests/test_readers.py
@@ -95,8 +95,14 @@ class TestAgilentReader(unittest.TestCase):
     def test_image_read(self):
         d = Orange.data.Table("agilent/4_noimage_agg256.seq")
         self.assertEqual(len(d), 64)
-        self.assertAlmostEqual(d[17]["map_x"], 6.28571428)
-        self.assertAlmostEqual(d[17]["map_y"], 12.57142857)
+        # Pixel sizes are 5.5 * 16 = 88.0 (binning to reduce test data)
+        self.assertAlmostEqual(
+            d[1]["map_x"] - d[0]["map_x"], 88.0)
+        self.assertAlmostEqual(
+            d[8]["map_y"] - d[7]["map_y"], 88.0)
+        # Last pixel should start at (8 - 1) * 88.0 = 616.0
+        self.assertAlmostEqual(d[-1]["map_x"], 616.0)
+        self.assertAlmostEqual(d[-1]["map_y"], 616.0)
         self.assertAlmostEqual(d[1][1], 1.27181053)
         self.assertAlmostEqual(d[2][2], 1.27506005)
         self.assertEqual(min(getx(d)), 1990.178226)
@@ -105,8 +111,15 @@ class TestAgilentReader(unittest.TestCase):
     def test_mosaic_read(self):
         d = Orange.data.Table("agilent/5_mosaic_agg1024.dms")
         self.assertEqual(len(d), 32)
-        self.assertAlmostEqual(d[31]["map_x"], 22.0)
-        self.assertAlmostEqual(d[31]["map_y"], 44.0)
+        # Pixel sizes are 5.5 * 32 = 176.0 (binning to reduce test data)
+        self.assertAlmostEqual(
+            d[1]["map_x"] - d[0]["map_x"], 176.0)
+        self.assertAlmostEqual(
+            d[4]["map_y"] - d[3]["map_y"], 176.0)
+        # Last pixel should start at (4 - 1) * 176.0 = 528.0
+        self.assertAlmostEqual(d[-1]["map_x"], 528.0)
+        # 1 x 2 mosiac, (8 - 1) * 176.0 = 1232.0
+        self.assertAlmostEqual(d[-1]["map_y"], 1232.0)
         self.assertAlmostEqual(d[1][1], 1.14792180)
         self.assertAlmostEqual(d[2][2], 1.14063489)
         self.assertEqual(min(getx(d)), 1990.178226)


### PR DESCRIPTION
This accounts for the pixel binning used in the test data sets and fixes an error in the np.linspace XY coordinate generation which resulted in incorrect pixel sizes.

The related tests have been fixed and I added comments to explain where the numbers come from this time.