### PR TITLE
Fix Normalization in Preprocess Spectra

### DIFF
--- a/orangecontrib/spectroscopy/preprocess.py
+++ b/orangecontrib/spectroscopy/preprocess.py
@@ -374,12 +374,13 @@ class _NormalizeCommon:
                                   limits=[[self.lower, self.upper]])(data)
             data.X /= norm_data.X
         elif self.method == Normalize.Attribute:
-            # attr normalization applies to entire spectrum, regardless of limits
-            # meta indices are -ve and start at -1
-            if self.attr not in (None, "None", ""):
-                attr_index = -1 - data.domain.index(self.attr)
-                factors = data.metas[:, attr_index].astype(float)
-                data.X /= factors[:, None]
+            if self.attr in data.domain and isinstance(data.domain[self.attr], Orange.data.ContinuousVariable):
+                ndom = Orange.data.Domain([data.domain[self.attr]])
+                factors = data.transform(ndom)
+                data.X /= factors.X
+                nd = data.domain[self.attr]
+            else:  # invalid attribute for normalization
+                data.X *= float("nan")
         return data.X
 
 

--- a/orangecontrib/spectroscopy/tests/test_preprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_preprocess.py
@@ -323,9 +323,11 @@ class TestNormalize(unittest.TestCase):
         np.testing.assert_equal(q.X, np.ones_like(q.X))
 
     def test_attribute_norm(self):
-        data = Orange.data.Table([[2, 1, 2, 2, 3]], metas=[[2]])
-        p = Normalize(method=Normalize.Attribute)(data)
-        np.testing.assert_equal(p.X, data.X)
+        data = Orange.data.Table([[2, 1, 2, 2, 3]])
+        ndom = Orange.data.Domain(data.domain.attributes, data.domain.class_vars,
+                                  metas=[Orange.data.ContinuousVariable("f")])
+        data = data.transform(ndom)
+        data[0]["f"] = 2
         p = Normalize(method=Normalize.Attribute, attr=data.domain.metas[0])(data)
         np.testing.assert_equal(p.X, data.X / 2)
         p = Normalize(method=Normalize.Attribute, attr=data.domain.metas[0],
@@ -334,6 +336,11 @@ class TestNormalize(unittest.TestCase):
         p = Normalize(method=Normalize.Attribute, attr=data.domain.metas[0],
                 lower=2, upper=4)(data)
         np.testing.assert_equal(p.X, data.X / 2)
+
+    def test_attribute_norm_unknown(self):
+        data = Orange.data.Table([[2, 1, 2, 2, 3]], metas=[[2]])
+        p = Normalize(method=Normalize.Attribute, attr="unknown")(data)
+        self.assertTrue(np.all(np.isnan(p.X)))
 
 
 class TestCommon(unittest.TestCase):


### PR DESCRIPTION
Normalize preprocessor now output nans if attribute is invalid. This fixes preprocessor crashes if data is changed.

Since changes in Orange (PR "DomainModel: Prevent modification except through set_domain") NormalizeEditor was crashing, therefore I refectored NormalizeEditor internals to use DomainModel. 

Also fixed saved attribute loading. 