### PR TITLE
Preprocess widget: add EMSC

### DIFF
--- a/orangecontrib/spectroscopy/data.py
+++ b/orangecontrib/spectroscopy/data.py
@@ -824,3 +824,7 @@ def getx(data):
     except:
         pass
     return x
+
+
+def spectra_mean(X):
+    return np.nanmean(X, axis=0, dtype=np.float64)

--- a/orangecontrib/spectroscopy/preprocess/emsc.py
+++ b/orangecontrib/spectroscopy/preprocess/emsc.py
@@ -38,11 +38,12 @@ class _EMSC(CommonDomainOrderUnknowns):
             M.append(wavenumbersSquared)
         if self.use_b:
             M.append(ref_X)
-        M = np.vstack(M).T
+        M = np.vstack(M).T if M else None  # edge case: no parameters selected
 
         newspectra = np.zeros(X.shape)
         for i, rawspectrum in enumerate(X):
-            m = np.linalg.lstsq(M, rawspectrum)[0]
+            if M is not None:
+                m = np.linalg.lstsq(M, rawspectrum)[0]
             corrected = rawspectrum
             n = 0
             if self.use_a:

--- a/orangecontrib/spectroscopy/preprocess/emsc.py
+++ b/orangecontrib/spectroscopy/preprocess/emsc.py
@@ -2,7 +2,7 @@ import Orange
 import numpy as np
 from Orange.preprocess.preprocess import Preprocess
 
-from orangecontrib.spectroscopy.data import getx
+from orangecontrib.spectroscopy.data import getx, spectra_mean
 from orangecontrib.spectroscopy.preprocess.utils import SelectColumn, CommonDomainOrderUnknowns, interp1d_with_unknowns_numpy
 
 
@@ -24,7 +24,7 @@ class _EMSC(CommonDomainOrderUnknowns):
         # about 85% of time in __call__ function is spent is lstsq
 
         # compute average spectrum from the reference
-        ref_X = np.atleast_2d(np.nanmean(self.reference.X, axis=0, dtype=np.float64))
+        ref_X = np.atleast_2d(spectra_mean(self.reference.X))
         # interpolate reference to the data
         ref_X = interp1d_with_unknowns_numpy(getx(self.reference), ref_X, wavenumbers)
 

--- a/orangecontrib/spectroscopy/preprocess/emsc.py
+++ b/orangecontrib/spectroscopy/preprocess/emsc.py
@@ -23,8 +23,10 @@ class _EMSC(CommonDomainOrderUnknowns):
     def transformed(self, X, wavenumbers):
         # about 85% of time in __call__ function is spent is lstsq
 
+        # compute average spectrum from the reference
+        ref_X = np.atleast_2d(np.nanmean(self.reference.X, axis=0, dtype=np.float64))
         # interpolate reference to the data
-        ref_X = interp1d_with_unknowns_numpy(getx(self.reference), self.reference.X, wavenumbers)
+        ref_X = interp1d_with_unknowns_numpy(getx(self.reference), ref_X, wavenumbers)
 
         wavenumbersSquared = wavenumbers * wavenumbers
         M = []
@@ -71,7 +73,8 @@ class EMSC(Preprocess):
         self.use_e = use_e
 
     def __call__(self, data):
-        common = _EMSC(self.reference, self.use_a, self.use_b, self.use_d, self.use_e, data.domain)  # creates function for transforming data
+        reference = self.reference if self.reference is not None else data
+        common = _EMSC(reference, self.use_a, self.use_b, self.use_d, self.use_e, data.domain)  # creates function for transforming data
         atts = [a.copy(compute_value=EMSCFeature(i, common))  # takes care of domain column-wise, by above transformation function
                 for i, a in enumerate(data.domain.attributes)]
         domain = Orange.data.Domain(atts, data.domain.class_vars,

--- a/orangecontrib/spectroscopy/preprocess/emsc.py
+++ b/orangecontrib/spectroscopy/preprocess/emsc.py
@@ -23,14 +23,16 @@ class _EMSC(CommonDomainOrderUnknowns):
     def transformed(self, X, wavenumbers):
         # about 85% of time in __call__ function is spent is lstsq
 
-        if not self.reference:
+        if self.reference:
+            # compute average spectrum from the reference
+            ref_X = np.atleast_2d(spectra_mean(self.reference.X))
+            # interpolate reference to the data
+            ref_X = interp1d_with_unknowns_numpy(getx(self.reference), ref_X, wavenumbers)
+        elif self.use_b:
             # can not do anything meaningful without reference
-            return np.zeros(X.shape)*np.nan
-
-        # compute average spectrum from the reference
-        ref_X = np.atleast_2d(spectra_mean(self.reference.X))
-        # interpolate reference to the data
-        ref_X = interp1d_with_unknowns_numpy(getx(self.reference), ref_X, wavenumbers)
+            return np.zeros(X.shape) * np.nan
+        else:
+            ref_X = None
 
         wavenumbersSquared = wavenumbers * wavenumbers
         M = []

--- a/orangecontrib/spectroscopy/preprocess/emsc.py
+++ b/orangecontrib/spectroscopy/preprocess/emsc.py
@@ -23,6 +23,10 @@ class _EMSC(CommonDomainOrderUnknowns):
     def transformed(self, X, wavenumbers):
         # about 85% of time in __call__ function is spent is lstsq
 
+        if not self.reference:
+            # can not do anything meaningful without reference
+            return np.zeros(X.shape)*np.nan
+
         # compute average spectrum from the reference
         ref_X = np.atleast_2d(spectra_mean(self.reference.X))
         # interpolate reference to the data
@@ -74,8 +78,7 @@ class EMSC(Preprocess):
         self.use_e = use_e
 
     def __call__(self, data):
-        reference = self.reference if self.reference is not None else data
-        common = _EMSC(reference, self.use_a, self.use_b, self.use_d, self.use_e, data.domain)  # creates function for transforming data
+        common = _EMSC(self.reference, self.use_a, self.use_b, self.use_d, self.use_e, data.domain)  # creates function for transforming data
         atts = [a.copy(compute_value=EMSCFeature(i, common))  # takes care of domain column-wise, by above transformation function
                 for i, a in enumerate(data.domain.attributes)]
         domain = Orange.data.Domain(atts, data.domain.class_vars,

--- a/orangecontrib/spectroscopy/tests/test_emsc.py
+++ b/orangecontrib/spectroscopy/tests/test_emsc.py
@@ -32,9 +32,7 @@ class TestEMSC(unittest.TestCase):
         data = Orange.data.Table([[1.0, 2.0, 1.0, 1.0],
                                   [3.0, 5.0, 3.0, 3.0]])
         fdata = EMSC(use_a=True, use_b=True, use_d=False, use_e=False)(data)
-        np.testing.assert_almost_equal(fdata.X,
-                                       [[2., 3.5, 2., 2.],
-                                        [2., 3.5, 2., 2.]])
+        np.testing.assert_almost_equal(fdata.X, np.nan)
 
     def test_none(self):
         data = Orange.data.Table([[1.0, 2.0, 1.0, 1.0],

--- a/orangecontrib/spectroscopy/tests/test_emsc.py
+++ b/orangecontrib/spectroscopy/tests/test_emsc.py
@@ -26,3 +26,12 @@ class TestEMSC(unittest.TestCase):
         np.testing.assert_almost_equal(fdata.X,
                                        [[1.0, 2.0, 1.0, 1.0],
                                         [1.0, 2.0, 1.0, 1.0]])
+
+    def test_no_reference(self):
+        # average from the data will be used
+        data = Orange.data.Table([[1.0, 2.0, 1.0, 1.0],
+                                  [3.0, 5.0, 3.0, 3.0]])
+        fdata = EMSC(use_a=True, use_b=True, use_d=False, use_e=False)(data)
+        np.testing.assert_almost_equal(fdata.X,
+                                       [[2., 3.5, 2., 2.],
+                                        [2., 3.5, 2., 2.]])

--- a/orangecontrib/spectroscopy/tests/test_emsc.py
+++ b/orangecontrib/spectroscopy/tests/test_emsc.py
@@ -34,6 +34,12 @@ class TestEMSC(unittest.TestCase):
         fdata = EMSC(use_a=True, use_b=True, use_d=False, use_e=False)(data)
         np.testing.assert_almost_equal(fdata.X, np.nan)
 
+        data = Orange.data.Table([[1.0, 2.0, 1.0, 1.0],
+                                  [3.0, 5.0, 3.0, 3.0]])
+        fdata = EMSC(use_a=True, use_b=False, use_d=False, use_e=False)(data)
+        np.testing.assert_almost_equal(fdata.X, [[-0.25, 0.75, -0.25, -0.25],
+                                                 [-0.5, 1.5, -0.5, -0.5]])
+
     def test_none(self):
         data = Orange.data.Table([[1.0, 2.0, 1.0, 1.0],
                                   [3.0, 5.0, 3.0, 3.0]])

--- a/orangecontrib/spectroscopy/tests/test_emsc.py
+++ b/orangecontrib/spectroscopy/tests/test_emsc.py
@@ -35,3 +35,12 @@ class TestEMSC(unittest.TestCase):
         np.testing.assert_almost_equal(fdata.X,
                                        [[2., 3.5, 2., 2.],
                                         [2., 3.5, 2., 2.]])
+
+    def test_none(self):
+        data = Orange.data.Table([[1.0, 2.0, 1.0, 1.0],
+                                  [3.0, 5.0, 3.0, 3.0]])
+        f = EMSC(reference=data[0:1], use_a=False, use_b=False, use_d=False, use_e=False)
+        fdata = f(data)
+        np.testing.assert_almost_equal(fdata.X,
+                                       [[1.0, 2.0, 1.0, 1.0],
+                                        [3.0, 5.0, 3.0, 3.0]])

--- a/orangecontrib/spectroscopy/widgets/owintegrate.py
+++ b/orangecontrib/spectroscopy/widgets/owintegrate.py
@@ -165,13 +165,15 @@ PREPROCESSORS = [
 ]
 
 
-class OWIntegrate(orangecontrib.spectroscopy.widgets.owpreprocess.OWPreprocess):
+class OWIntegrate(orangecontrib.spectroscopy.widgets.owpreprocess.SpectralPreprocess):
     name = "Integrate Spectra"
     id = "orangecontrib.spectroscopy.widgets.integrate"
     description = "Integrate spectra in various ways."
     icon = "icons/integrate.svg"
     priority = 1010
     replaces = ["orangecontrib.infrared.widgets.owintegrate.OWIntegrate"]
+
+    settings_version = 2
 
     PREPROCESSORS = PREPROCESSORS
     BUTTON_ADD_LABEL = "Add integral..."

--- a/orangecontrib/spectroscopy/widgets/owpreprocess.py
+++ b/orangecontrib/spectroscopy/widgets/owpreprocess.py
@@ -1197,11 +1197,15 @@ class EMSCEditor(BaseEditor, OWComponent):
         self.scaling = self.SCALING_DEFAULT
         gui.checkBox(self, self, "scaling", "Scaling", callback=self.edited.emit)
 
+        self.reference_info = QLabel("", self)
+        self.layout().addWidget(self.reference_info)
+
         self.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Preferred)
 
         self.reference_curve = pg.PlotCurveItem()
         self.reference_curve.setPen(pg.mkPen(color=QColor(Qt.red), width=2.))
         self.reference_curve.setZValue(10)
+        self.set_reference_data(self.reference)  # update reference info
 
     def activateOptions(self):
         self.parent_widget.curveplot.clear_markings()
@@ -1230,7 +1234,14 @@ class EMSCEditor(BaseEditor, OWComponent):
         self.reference = ref
         if not self.reference:
             self.reference_curve.hide()
+            self.reference_info.setText("Reference missing!")
+            self.reference_info.setStyleSheet("color: red")
         else:
+            if len(self.reference) > 1:
+                self.reference_info.setText("Reference: mean of %d spectra" % len(self.reference))
+            else:
+                self.reference_info.setText("Reference: 1 spectrum")
+            self.reference_info.setStyleSheet("color: black")
             X_ref = spectra_mean(self.reference.X)
             x = getx(self.reference)
             xsind = np.argsort(x)

--- a/orangecontrib/spectroscopy/widgets/owpreprocess.py
+++ b/orangecontrib/spectroscopy/widgets/owpreprocess.py
@@ -1331,15 +1331,7 @@ class TimeoutLabel(QLabel):
         self.animation.start()
 
 
-class OWPreprocess(OWWidget):
-    name = "Preprocess Spectra"
-    description = "Construct a data preprocessing pipeline."
-    icon = "icons/preprocess.svg"
-    priority = 1000
-    replaces = ["orangecontrib.infrared.widgets.owpreproc.OWPreprocess",
-                "orangecontrib.infrared.widgets.owpreprocess.OWPreprocess"]
-
-    settings_version = 2
+class SpectralPreprocess(OWWidget):
 
     class Inputs:
         data = Input("Data", Orange.data.Table, default=True)
@@ -1355,9 +1347,6 @@ class OWPreprocess(OWWidget):
 
     curveplot = settings.SettingProvider(CurvePlot)
     curveplot_after = settings.SettingProvider(CurvePlot)
-
-    BUTTON_ADD_LABEL = "Add preprocessor..."
-    PREPROCESSORS = PREPROCESSORS
 
     # draw preview on top of current image
     preview_on_image = False
@@ -1746,6 +1735,24 @@ class OWPreprocess(OWWidget):
         if "storedsettings" in settings_ and "preprocessors" in settings_["storedsettings"]:
             settings_["storedsettings"]["preprocessors"], _ = \
                 cls.migrate_preprocessors(settings_["storedsettings"]["preprocessors"], version)
+
+
+class OWPreprocess(SpectralPreprocess):
+
+    name = "Preprocess Spectra"
+    description = "Construct a data preprocessing pipeline."
+    icon = "icons/preprocess.svg"
+    priority = 1000
+    replaces = ["orangecontrib.infrared.widgets.owpreproc.OWPreprocess",
+                "orangecontrib.infrared.widgets.owpreprocess.OWPreprocess"]
+
+    settings_version = 2
+
+    BUTTON_ADD_LABEL = "Add preprocessor..."
+    PREPROCESSORS = PREPROCESSORS
+
+    # draw preview on top of current image
+    preview_on_image = False
 
 
 def test_main(argv=sys.argv):


### PR DESCRIPTION
I added simple EMSC to the "Preprocess Spectra" widget.

To do EMSC, we need a reference spectrum. Therefore I needed to add "Reference" input to the "Preprocess Spectra".

Are there any other preprocessors that would need something similar? I remember @clsandt once suggesting subtraction that would need something similar. Also, @stuart-cls made some preprocessors that use reference (Transmittance and Absorbance, but these were not passed from the widget).

If we add the "Reference" input (the alternative is to make a new widget that would be essentially the same but with different inputs), which name for the input would make sense? @borondics ?