### PR TITLE
Temporary workaround for needles data copy in annotated data

### DIFF
--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -38,8 +38,8 @@ from orangecontrib.spectroscopy.widgets.owspectra import InteractiveViewBox, \
 from orangecontrib.spectroscopy.widgets.owpreprocess import MovableVlineWD
 from orangecontrib.spectroscopy.widgets.line_geometry import in_polygon
 
-from Orange.widgets.utils.annotated_data import create_annotated_table, ANNOTATED_DATA_SIGNAL_NAME
-from orangecontrib.spectroscopy.widgets.owspectra import create_groups_table  # compatibility with Orange 3.6.0-
+from Orange.widgets.utils.annotated_data import create_annotated_table, ANNOTATED_DATA_SIGNAL_NAME, \
+    create_groups_table
 
 
 IMAGE_TOO_BIG = 1024*1024
@@ -789,8 +789,10 @@ class OWHyper(OWWidget):
 
         indices = np.flatnonzero(self.imageplot.selection_group)
 
-        self.Outputs.annotated_data.send(
-                  create_groups_table(self.imageplot.data, self.imageplot.selection_group))
+        annotated_data = create_groups_table(self.data, self.imageplot.selection_group)
+        if annotated_data is not None:
+            annotated_data.X = self.data.X  # workaround for Orange's copying on domain conversio
+        self.Outputs.annotated_data.send(annotated_data)
 
         selected = self.data[indices]
         self.Outputs.selected_data.send(selected if selected else None)

--- a/orangecontrib/spectroscopy/widgets/owspectra.py
+++ b/orangecontrib/spectroscopy/widgets/owspectra.py
@@ -1343,8 +1343,11 @@ class OWSpectra(OWWidget):
 
     def selection_changed(self):
         # selection table
-        self.Outputs.annotated_data.send(
-            create_groups_table(self.curveplot.data, self.curveplot.selection_group))
+        annotated_data = create_groups_table(self.curveplot.data, self.curveplot.selection_group)
+        if annotated_data is not None:
+            annotated_data.X = self.curveplot.data.X  # workaround for Orange's copying on domain conversion
+        self.Outputs.annotated_data.send(annotated_data)
+
         # selected elements
         selected = None
         if self.curveplot.data:


### PR DESCRIPTION
This should be fixed in Orange, because many widgets have the same problems.

Domain in Orange transformations waste memory, because they copy X even though the same X could be used.

Now I have only temporarily fixed this for the viewers, but at least Integrate and Reshape suffer from the same problems.

A reference bug: #119 